### PR TITLE
Feat/#53 user service

### DIFF
--- a/src/main/java/com/programmers/smrtstore/domain/auth/jwt/JwtAuthentication.java
+++ b/src/main/java/com/programmers/smrtstore/domain/auth/jwt/JwtAuthentication.java
@@ -3,6 +3,7 @@ package com.programmers.smrtstore.domain.auth.jwt;
 import java.util.Date;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.stereotype.Component;
 
 @Getter
 @Builder

--- a/src/main/java/com/programmers/smrtstore/domain/auth/jwt/JwtAuthenticationProvider.java
+++ b/src/main/java/com/programmers/smrtstore/domain/auth/jwt/JwtAuthenticationProvider.java
@@ -31,7 +31,6 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
     public Authentication authenticate(Authentication authentication)
         throws AuthenticationException {
         JwtAuthenticationToken jwtAuthenticationToken = (JwtAuthenticationToken) authentication;
-        log.info("authenticate 시작");
         return processUserAuthentication(
             String.valueOf(jwtAuthenticationToken.getPrincipal()),
             jwtAuthenticationToken.getCredentials()

--- a/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
@@ -37,7 +37,9 @@ public class UserService {
         User user = userRepository.findByAuth_LoginId(principal)
             .orElseThrow(
                 () -> new UserException(USER_NOT_FOUND, principal));
-        if(user.getDeletedAt() != null) throw new UserException(USER_NOT_FOUND, principal);
+        if (user.getDeletedAt() != null) {
+            throw new UserException(USER_NOT_FOUND, principal);
+        }
         user.checkPassword(passwordEncoder, credentials);
         return user;
     }

--- a/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
@@ -2,7 +2,6 @@ package com.programmers.smrtstore.domain.user.application;
 
 import static com.programmers.smrtstore.core.properties.ErrorCode.DUPLICATE_LOGIN_ID;
 import static com.programmers.smrtstore.core.properties.ErrorCode.USER_NOT_FOUND;
-import static com.programmers.smrtstore.domain.user.domain.entity.User.toUser;
 import static com.programmers.smrtstore.domain.user.presentation.dto.res.DetailUserResponse.toDetailUserResponse;
 import static com.programmers.smrtstore.domain.user.presentation.dto.res.SignUpUserResponse.toSignUpUserResponse;
 
@@ -56,7 +55,7 @@ public class UserService {
     }
 
     public SignUpUserResponse signUp(SignUpUserRequest request) {
-        User user = toUser(request, passwordEncoder);
+        User user = request.toUser(passwordEncoder);
         User saved = userRepository.save(user);
         return toSignUpUserResponse(saved);
     }
@@ -66,8 +65,7 @@ public class UserService {
         user.updateUser(request.getLoginId(), request.getPassword(), request.getAge(),
             request.getNickName(),
             request.getEmail(), request.getPhone(), request.getBirth(), request.getGender(),
-            request.getThumbnail(), request.isMarketingAgree(), request.isMembershipYN(),
-            request.isRepurchaseYN(), passwordEncoder);
+            request.getThumbnail(), request.isMarketingAgree(), passwordEncoder);
         return toDetailUserResponse(user);
     }
 

--- a/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
@@ -75,7 +75,8 @@ public class UserService {
     public DetailUserResponse update(Long userId, UpdateUserRequest request) {
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new UserException(USER_NOT_FOUND, String.valueOf(userId)));
-        user.updateUser(request.getLoginId(), request.getPassword(), request.getAge(), request.getNickName(),
+        user.updateUser(request.getLoginId(), request.getPassword(), request.getAge(),
+            request.getNickName(),
             request.getEmail(), request.getPhone(), request.getBirth(), request.getGender(),
             request.getThumbnail(), request.isMarketingAgree(), request.isMembershipYN(),
             request.isRepurchaseYN());

--- a/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
@@ -16,7 +16,6 @@ import com.programmers.smrtstore.domain.user.presentation.dto.res.DetailUserResp
 import com.programmers.smrtstore.domain.user.presentation.dto.res.SignUpUserResponse;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -26,7 +25,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional
-@Slf4j
 public class UserService {
 
     private final PasswordEncoder passwordEncoder;

--- a/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
@@ -42,8 +42,9 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public void checkDuplicate(String loginId) {
-        if(userRepository.findByAuth_LoginId(loginId).isPresent())
+        if (userRepository.findByAuth_LoginId(loginId).isPresent()) {
             throw new UserException(DUPLICATE_LOGIN_ID, loginId);
+        }
     }
 
     @Transactional(readOnly = true)
@@ -70,8 +71,14 @@ public class UserService {
         return toDetailUserResponse(user);
     }
 
-    public Long updateUser(Long userId, UpdateUserRequest request) {
-        return null;
+    public DetailUserResponse updateUser(Long userId, UpdateUserRequest request) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new UserException(USER_NOT_FOUND, String.valueOf(userId)));
+        user.updateUser(request.getLoginId(), request.getPassword(), request.getAge(),
+            request.getNickName(),
+            request.getEmail(), request.getPhone(), request.getBirth(), request.getGender(),
+            request.getThumbnail(), request.isMarketingAgree(), request.isMembershipYN());
+        return toDetailUserResponse(user);
     }
 
     public Long deleteUser(Long userId) {

--- a/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
@@ -1,5 +1,6 @@
 package com.programmers.smrtstore.domain.user.application;
 
+import static com.programmers.smrtstore.core.properties.ErrorCode.DUPLICATE_LOGIN_ID;
 import static com.programmers.smrtstore.core.properties.ErrorCode.USER_NOT_FOUND;
 import static com.programmers.smrtstore.domain.user.domain.entity.User.toUser;
 import static com.programmers.smrtstore.domain.user.presentation.dto.res.SignUpUserResponse.toSignUpUserResponse;
@@ -11,7 +12,6 @@ import com.programmers.smrtstore.domain.user.presentation.dto.req.SignUpUserRequ
 import com.programmers.smrtstore.domain.user.presentation.dto.req.UpdateUserRequest;
 import com.programmers.smrtstore.domain.user.presentation.dto.res.DetailUserResponse;
 import com.programmers.smrtstore.domain.user.presentation.dto.res.SignUpUserResponse;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -46,8 +46,9 @@ public class UserService {
 //    }
 
     @Transactional(readOnly = true)
-    public Optional<User> findByLoginId(String loginId) {
-        return userRepository.findByAuth_LoginId(loginId);
+    public void findByLoginId(String loginId) {
+        userRepository.findByAuth_LoginId(loginId)
+            .orElseThrow(() -> new UserException(DUPLICATE_LOGIN_ID, loginId));
     }
 
     public SignUpUserResponse signUp(SignUpUserRequest request) {
@@ -56,8 +57,11 @@ public class UserService {
         return toSignUpUserResponse(saved);
     }
 
+    @Transactional(readOnly = true)
     public DetailUserResponse findByUserId(Long userId) {
-        return null;
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new UserException(USER_NOT_FOUND, String.valueOf(userId)));
+        return DetailUserResponse.toDetailUserResponse(user);
     }
 
     public Long updateUser(Long userId, UpdateUserRequest request) {

--- a/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
@@ -61,13 +61,6 @@ public class UserService {
         return toSignUpUserResponse(saved);
     }
 
-    @Transactional(readOnly = true)
-    public DetailUserResponse findByUserId(Long userId) {
-        User user = userRepository.findById(userId)
-            .orElseThrow(() -> new UserException(USER_NOT_FOUND, String.valueOf(userId)));
-        return toDetailUserResponse(user);
-    }
-
     public DetailUserResponse update(UpdateUserRequest request) {
         User user = certificatedUser();
         user.updateUser(request.getLoginId(), request.getPassword(), request.getAge(),

--- a/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
@@ -14,6 +14,7 @@ import com.programmers.smrtstore.domain.user.presentation.dto.req.SignUpUserRequ
 import com.programmers.smrtstore.domain.user.presentation.dto.req.UpdateUserRequest;
 import com.programmers.smrtstore.domain.user.presentation.dto.res.DetailUserResponse;
 import com.programmers.smrtstore.domain.user.presentation.dto.res.SignUpUserResponse;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
@@ -71,17 +72,20 @@ public class UserService {
         return toDetailUserResponse(user);
     }
 
-    public DetailUserResponse updateUser(Long userId, UpdateUserRequest request) {
+    public DetailUserResponse update(Long userId, UpdateUserRequest request) {
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new UserException(USER_NOT_FOUND, String.valueOf(userId)));
-        user.updateUser(request.getLoginId(), request.getPassword(), request.getAge(),
-            request.getNickName(),
+        user.updateUser(request.getLoginId(), request.getPassword(), request.getAge(), request.getNickName(),
             request.getEmail(), request.getPhone(), request.getBirth(), request.getGender(),
-            request.getThumbnail(), request.isMarketingAgree(), request.isMembershipYN());
+            request.getThumbnail(), request.isMarketingAgree(), request.isMembershipYN(),
+            request.isRepurchaseYN());
         return toDetailUserResponse(user);
     }
 
-    public Long deleteUser(Long userId) {
-        return null;
+    public DetailUserResponse withdraw(Long userId) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new UserException(USER_NOT_FOUND, String.valueOf(userId)));
+        user.saveDeleteDate(LocalDateTime.now());
+        return toDetailUserResponse(user);
     }
 }

--- a/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
@@ -74,7 +74,7 @@ public class UserService {
             request.getNickName(),
             request.getEmail(), request.getPhone(), request.getBirth(), request.getGender(),
             request.getThumbnail(), request.isMarketingAgree(), request.isMembershipYN(),
-            request.isRepurchaseYN());
+            request.isRepurchaseYN(), passwordEncoder);
         return toDetailUserResponse(user);
     }
 

--- a/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
@@ -42,8 +42,8 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public void checkDuplicate(String loginId) {
-        userRepository.findByAuth_LoginId(loginId)
-            .orElseThrow(() -> new UserException(DUPLICATE_LOGIN_ID, loginId));
+        if(userRepository.findByAuth_LoginId(loginId).isPresent())
+            throw new UserException(DUPLICATE_LOGIN_ID, loginId);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/programmers/smrtstore/domain/user/domain/entity/Auth.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/domain/entity/Auth.java
@@ -37,6 +37,11 @@ public class Auth {
         this.password = password;
     }
 
+    public void updateAuth(String loginId, String password) {
+        this.loginId = loginId;
+        this.password = password;
+    }
+
     public static Auth toAuth(String loginId, String password, PasswordEncoder passwordEncoder) {
         return new Auth(loginId, passwordEncoder.encode(password));
     }

--- a/src/main/java/com/programmers/smrtstore/domain/user/domain/entity/Auth.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/domain/entity/Auth.java
@@ -37,9 +37,12 @@ public class Auth {
         this.password = password;
     }
 
-    public void updateAuth(String loginId, String password) {
+    public void updateLoginId(String loginId) {
         this.loginId = loginId;
-        this.password = password;
+    }
+
+    public void updatePassword(String password, PasswordEncoder passwordEncoder) {
+        this.password = passwordEncoder.encode(password);
     }
 
     public static Auth toAuth(String loginId, String password, PasswordEncoder passwordEncoder) {

--- a/src/main/java/com/programmers/smrtstore/domain/user/domain/entity/Auth.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/domain/entity/Auth.java
@@ -25,7 +25,7 @@ public class Auth {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, length = 50)
+    @Column(nullable = false, length = 50, unique = true)
     private String loginId;
 
 

--- a/src/main/java/com/programmers/smrtstore/domain/user/domain/entity/User.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/domain/entity/User.java
@@ -64,6 +64,7 @@ public class User {
     @Enumerated(EnumType.STRING)
     private Gender gender;
 
+    @Column(columnDefinition = "BLOB")
     private String thumbnail;
 
     @Column(nullable = false)
@@ -76,7 +77,7 @@ public class User {
     @Column(nullable = false)
     private boolean marketingAgree;
 
-    @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
+    @Column(nullable = false)
     private boolean membershipYN;
 
     @Column(nullable = false)
@@ -118,6 +119,22 @@ public class User {
         return Stream.of(new SimpleGrantedAuthority(role.name()))
             .map(GrantedAuthority.class::cast)
             .toList();
+    }
+
+    public void updateUser(String loginId, String password, Integer age, String nickName,
+        String email, String phone,
+        String birth, Gender gender, String thumbnail, boolean marketingAgree,
+        boolean membershipYN) {
+        this.getAuth().updateAuth(loginId, password);
+        this.age = age;
+        this.nickName = nickName;
+        this.email = email;
+        this.phone = phone;
+        this.birth = birth;
+        this.gender = gender;
+        this.thumbnail = thumbnail;
+        this.marketingAgree = marketingAgree;
+        this.membershipYN = membershipYN;
     }
 
     public static User toUser(SignUpUserRequest request, PasswordEncoder passwordEncoder) {

--- a/src/main/java/com/programmers/smrtstore/domain/user/domain/entity/User.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/domain/entity/User.java
@@ -122,8 +122,9 @@ public class User {
     public void updateUser(String loginId, String password, Integer age, String nickName,
         String email, String phone, String birth, Gender gender, String thumbnail,
         boolean marketingAgree,
-        boolean membershipYN, boolean repurchaseYN) {
-        this.getAuth().updateAuth(loginId, password);
+        boolean membershipYN, boolean repurchaseYN, PasswordEncoder passwordEncoder) {
+        this.getAuth().updateLoginId(loginId);
+        this.getAuth().updatePassword(password, passwordEncoder);
         this.age = age;
         this.nickName = nickName;
         this.email = email;

--- a/src/main/java/com/programmers/smrtstore/domain/user/domain/entity/User.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/domain/entity/User.java
@@ -1,10 +1,8 @@
 package com.programmers.smrtstore.domain.user.domain.entity;
 
 import static com.programmers.smrtstore.core.properties.ErrorCode.INCORRECT_PASSWORD;
-import static com.programmers.smrtstore.domain.user.domain.entity.Auth.toAuth;
 
 import com.programmers.smrtstore.domain.user.exception.UserException;
-import com.programmers.smrtstore.domain.user.presentation.dto.req.SignUpUserRequest;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -121,8 +119,7 @@ public class User {
 
     public void updateUser(String loginId, String password, Integer age, String nickName,
         String email, String phone, String birth, Gender gender, String thumbnail,
-        boolean marketingAgree,
-        boolean membershipYN, boolean repurchaseYN, PasswordEncoder passwordEncoder) {
+        boolean marketingAgree, PasswordEncoder passwordEncoder) {
         this.getAuth().updateLoginId(loginId);
         this.getAuth().updatePassword(password, passwordEncoder);
         this.age = age;
@@ -133,26 +130,21 @@ public class User {
         this.gender = gender;
         this.thumbnail = thumbnail;
         this.marketingAgree = marketingAgree;
-        this.membershipYN = membershipYN;
-        this.repurchaseYN = repurchaseYN;
+    }
+
+    public void repurchase() {
+        this.repurchaseYN = true;
+    }
+
+    public void joinMembership() {
+        this.membershipYN = true;
+    }
+
+    public void withdrawMembership() {
+        this.membershipYN = false;
     }
 
     public void saveDeleteDate(LocalDateTime time) {
         this.deletedAt = time;
-    }
-
-    public static User toUser(SignUpUserRequest request, PasswordEncoder passwordEncoder) {
-        Auth auth = toAuth(request.getLoginId(), request.getPassword(), passwordEncoder);
-        return new User(
-            auth,
-            request.getAge(),
-            request.getBirth(),
-            request.getEmail(),
-            request.getGender(),
-            request.getRole(),
-            request.getPhone(),
-            request.isMarketingAgree(),
-            request.getNickName(),
-            request.getThumbnail());
     }
 }

--- a/src/main/java/com/programmers/smrtstore/domain/user/domain/entity/User.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/domain/entity/User.java
@@ -120,7 +120,8 @@ public class User {
     }
 
     public void updateUser(String loginId, String password, Integer age, String nickName,
-        String email, String phone, String birth, Gender gender, String thumbnail, boolean marketingAgree,
+        String email, String phone, String birth, Gender gender, String thumbnail,
+        boolean marketingAgree,
         boolean membershipYN, boolean repurchaseYN) {
         this.getAuth().updateAuth(loginId, password);
         this.age = age;

--- a/src/main/java/com/programmers/smrtstore/domain/user/domain/entity/User.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/domain/entity/User.java
@@ -81,7 +81,7 @@ public class User {
     private boolean membershipYN;
 
     @Column(nullable = false)
-    private boolean repurchase;
+    private boolean repurchaseYN;
 
     @UpdateTimestamp
     private LocalDateTime updatedAt;
@@ -93,15 +93,13 @@ public class User {
     private LocalDateTime deletedAt;
 
     public User(Auth auth, Integer age, String birth, String email, Gender gender, Role role,
-        boolean membershipYN, String phone, boolean marketingAgree,
-        String nickName, String thumbnail) {
+        String phone, boolean marketingAgree, String nickName, String thumbnail) {
         this.age = age;
         this.auth = auth;
         this.birth = birth;
         this.email = email;
         this.gender = gender;
         this.role = role;
-        this.membershipYN = membershipYN;
         this.phone = phone;
         this.marketingAgree = marketingAgree;
         this.nickName = nickName;
@@ -122,9 +120,8 @@ public class User {
     }
 
     public void updateUser(String loginId, String password, Integer age, String nickName,
-        String email, String phone,
-        String birth, Gender gender, String thumbnail, boolean marketingAgree,
-        boolean membershipYN) {
+        String email, String phone, String birth, Gender gender, String thumbnail, boolean marketingAgree,
+        boolean membershipYN, boolean repurchaseYN) {
         this.getAuth().updateAuth(loginId, password);
         this.age = age;
         this.nickName = nickName;
@@ -135,6 +132,11 @@ public class User {
         this.thumbnail = thumbnail;
         this.marketingAgree = marketingAgree;
         this.membershipYN = membershipYN;
+        this.repurchaseYN = repurchaseYN;
+    }
+
+    public void saveDeleteDate(LocalDateTime time) {
+        this.deletedAt = time;
     }
 
     public static User toUser(SignUpUserRequest request, PasswordEncoder passwordEncoder) {
@@ -146,7 +148,6 @@ public class User {
             request.getEmail(),
             request.getGender(),
             request.getRole(),
-            request.isMembershipYN(),
             request.getPhone(),
             request.isMarketingAgree(),
             request.getNickName(),

--- a/src/main/java/com/programmers/smrtstore/domain/user/infrastructure/UserRepository.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/infrastructure/UserRepository.java
@@ -6,6 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-
     Optional<User> findByAuth_LoginId(String loginId);
 }

--- a/src/main/java/com/programmers/smrtstore/domain/user/presentation/controller/AuthController.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/presentation/controller/AuthController.java
@@ -4,14 +4,20 @@ import static com.programmers.smrtstore.domain.user.presentation.dto.res.DetailA
 
 import com.programmers.smrtstore.domain.auth.jwt.JwtAuthentication;
 import com.programmers.smrtstore.domain.auth.jwt.JwtAuthenticationToken;
+import com.programmers.smrtstore.domain.user.application.UserService;
 import com.programmers.smrtstore.domain.user.domain.entity.User;
 import com.programmers.smrtstore.domain.user.presentation.dto.req.LoginRequest;
+import com.programmers.smrtstore.domain.user.presentation.dto.req.SignUpUserRequest;
 import com.programmers.smrtstore.domain.user.presentation.dto.res.DetailAuthResponse;
+import com.programmers.smrtstore.domain.user.presentation.dto.res.SignUpUserResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,6 +29,20 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthenticationManager authenticationManager;
+    private final UserService userService;
+
+    @PostMapping
+    public ResponseEntity<SignUpUserResponse> signUp(
+        @RequestBody @Valid SignUpUserRequest request) {
+        SignUpUserResponse response = userService.signUp(request);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/exists/{loginId}")
+    public ResponseEntity<String> checkDuplication(@PathVariable @NotEmpty String loginId) {
+        userService.checkDuplicate(loginId);
+        return ResponseEntity.ok("사용 가능한 아이디입니다.");
+    }
 
     @PostMapping("/login")
     public ResponseEntity<DetailAuthResponse> login(@RequestBody @Valid LoginRequest request) {

--- a/src/main/java/com/programmers/smrtstore/domain/user/presentation/controller/AuthController.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/presentation/controller/AuthController.java
@@ -1,6 +1,6 @@
 package com.programmers.smrtstore.domain.user.presentation.controller;
 
-import static com.programmers.smrtstore.domain.user.presentation.dto.res.DetailAuthResponse.toDetailUserResponse;
+import static com.programmers.smrtstore.domain.user.presentation.dto.res.DetailAuthResponse.toDetailAuthResponse;
 
 import com.programmers.smrtstore.domain.auth.jwt.JwtAuthentication;
 import com.programmers.smrtstore.domain.auth.jwt.JwtAuthenticationToken;
@@ -51,7 +51,7 @@ public class AuthController {
         Authentication resultToken = authenticationManager.authenticate(authToken);
         JwtAuthentication authentication = (JwtAuthentication) resultToken.getPrincipal();
         User user = (User) resultToken.getDetails();
-        DetailAuthResponse response = toDetailUserResponse(authentication, user);
+        DetailAuthResponse response = toDetailAuthResponse(authentication, user);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/programmers/smrtstore/domain/user/presentation/controller/AuthController.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/presentation/controller/AuthController.java
@@ -31,7 +31,7 @@ public class AuthController {
     private final AuthenticationManager authenticationManager;
     private final UserService userService;
 
-    @PostMapping
+    @PostMapping("/signUp")
     public ResponseEntity<SignUpUserResponse> signUp(
         @RequestBody @Valid SignUpUserRequest request) {
         SignUpUserResponse response = userService.signUp(request);

--- a/src/main/java/com/programmers/smrtstore/domain/user/presentation/controller/AuthController.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/presentation/controller/AuthController.java
@@ -1,12 +1,12 @@
 package com.programmers.smrtstore.domain.user.presentation.controller;
 
-import static com.programmers.smrtstore.domain.user.presentation.dto.res.DetailUserResponse.toDetailUserResponse;
+import static com.programmers.smrtstore.domain.user.presentation.dto.res.DetailAuthResponse.toDetailUserResponse;
 
 import com.programmers.smrtstore.domain.auth.jwt.JwtAuthentication;
 import com.programmers.smrtstore.domain.auth.jwt.JwtAuthenticationToken;
 import com.programmers.smrtstore.domain.user.domain.entity.User;
 import com.programmers.smrtstore.domain.user.presentation.dto.req.LoginRequest;
-import com.programmers.smrtstore.domain.user.presentation.dto.res.DetailUserResponse;
+import com.programmers.smrtstore.domain.user.presentation.dto.res.DetailAuthResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -25,13 +25,13 @@ public class AuthController {
     private final AuthenticationManager authenticationManager;
 
     @PostMapping("/login")
-    public ResponseEntity<DetailUserResponse> login(@RequestBody @Valid LoginRequest request) {
+    public ResponseEntity<DetailAuthResponse> login(@RequestBody @Valid LoginRequest request) {
         JwtAuthenticationToken authToken = new JwtAuthenticationToken(request.getPrincipal(),
             request.getCredentials());
         Authentication resultToken = authenticationManager.authenticate(authToken);
         JwtAuthentication authentication = (JwtAuthentication) resultToken.getPrincipal();
         User user = (User) resultToken.getDetails();
-        DetailUserResponse response = toDetailUserResponse(authentication, user);
+        DetailAuthResponse response = toDetailUserResponse(authentication, user);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/programmers/smrtstore/domain/user/presentation/controller/UserController.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/presentation/controller/UserController.java
@@ -1,14 +1,14 @@
 package com.programmers.smrtstore.domain.user.presentation.controller;
 
-import static com.programmers.smrtstore.core.properties.ErrorCode.DUPLICATE_LOGIN_ID;
-
 import com.programmers.smrtstore.domain.user.application.UserService;
-import com.programmers.smrtstore.domain.user.exception.UserException;
 import com.programmers.smrtstore.domain.user.presentation.dto.req.SignUpUserRequest;
+import com.programmers.smrtstore.domain.user.presentation.dto.res.DetailUserResponse;
 import com.programmers.smrtstore.domain.user.presentation.dto.res.SignUpUserResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,14 +19,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/auth/user")
 @RequiredArgsConstructor
+@Validated
 public class UserController {
 
     private final UserService userService;
 
     @GetMapping("/exists/{loginId}")
-    public ResponseEntity<String> checkDuplication(@PathVariable String loginId) {
-        userService.findByLoginId(loginId)
-            .orElseThrow(() -> new UserException(DUPLICATE_LOGIN_ID, loginId));
+    public ResponseEntity<String> checkDuplication(@PathVariable @NotEmpty String loginId) {
+        userService.findByLoginId(loginId);
         return ResponseEntity.ok("사용 가능한 아이디입니다.");
     }
 
@@ -34,6 +34,12 @@ public class UserController {
     public ResponseEntity<SignUpUserResponse> signUp(
         @RequestBody @Valid SignUpUserRequest request) {
         SignUpUserResponse response = userService.signUp(request);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<DetailUserResponse> findByUserId(@PathVariable Long userId) {
+        DetailUserResponse response = userService.findByUserId(userId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/programmers/smrtstore/domain/user/presentation/controller/UserController.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/presentation/controller/UserController.java
@@ -28,20 +28,20 @@ public class UserController {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping("/me")
+    @GetMapping
     public ResponseEntity<DetailUserResponse> me() {
         DetailUserResponse response = userService.getUserInfo();
         return ResponseEntity.ok(response);
     }
 
-    @PostMapping("/update")
+    @PostMapping
     public ResponseEntity<DetailUserResponse> update(@RequestBody
     UpdateUserRequest request) {
         DetailUserResponse response = userService.update(request);
         return ResponseEntity.ok(response);
     }
 
-    @DeleteMapping("/withdraw")
+    @DeleteMapping
     public ResponseEntity<DetailUserResponse> withdraw() {
         DetailUserResponse response = userService.withdraw();
         return ResponseEntity.ok(response);

--- a/src/main/java/com/programmers/smrtstore/domain/user/presentation/controller/UserController.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/presentation/controller/UserController.java
@@ -4,11 +4,9 @@ import com.programmers.smrtstore.domain.user.application.UserService;
 import com.programmers.smrtstore.domain.user.presentation.dto.req.UpdateUserRequest;
 import com.programmers.smrtstore.domain.user.presentation.dto.res.DetailUserResponse;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,7 +15,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/auth/user")
 @RequiredArgsConstructor
-@Slf4j
 public class UserController {
 
     private final UserService userService;

--- a/src/main/java/com/programmers/smrtstore/domain/user/presentation/controller/UserController.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/presentation/controller/UserController.java
@@ -1,45 +1,32 @@
 package com.programmers.smrtstore.domain.user.presentation.controller;
 
 import com.programmers.smrtstore.domain.user.application.UserService;
-import com.programmers.smrtstore.domain.user.presentation.dto.req.SignUpUserRequest;
 import com.programmers.smrtstore.domain.user.presentation.dto.res.DetailUserResponse;
-import com.programmers.smrtstore.domain.user.presentation.dto.res.SignUpUserResponse;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotEmpty;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/auth/user")
 @RequiredArgsConstructor
-@Validated
+@Slf4j
 public class UserController {
 
     private final UserService userService;
 
-    @GetMapping("/exists/{loginId}")
-    public ResponseEntity<String> checkDuplication(@PathVariable @NotEmpty String loginId) {
-        userService.findByLoginId(loginId);
-        return ResponseEntity.ok("사용 가능한 아이디입니다.");
-    }
-
-    @PostMapping
-    public ResponseEntity<SignUpUserResponse> signUp(
-        @RequestBody @Valid SignUpUserRequest request) {
-        SignUpUserResponse response = userService.signUp(request);
-        return ResponseEntity.ok(response);
-    }
-
     @GetMapping("/{userId}")
     public ResponseEntity<DetailUserResponse> findByUserId(@PathVariable Long userId) {
         DetailUserResponse response = userService.findByUserId(userId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<DetailUserResponse> me() {
+        DetailUserResponse response = userService.getUserInfo();
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/programmers/smrtstore/domain/user/presentation/controller/UserController.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/presentation/controller/UserController.java
@@ -1,12 +1,15 @@
 package com.programmers.smrtstore.domain.user.presentation.controller;
 
 import com.programmers.smrtstore.domain.user.application.UserService;
+import com.programmers.smrtstore.domain.user.presentation.dto.req.UpdateUserRequest;
 import com.programmers.smrtstore.domain.user.presentation.dto.res.DetailUserResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -27,6 +30,13 @@ public class UserController {
     @GetMapping("/me")
     public ResponseEntity<DetailUserResponse> me() {
         DetailUserResponse response = userService.getUserInfo();
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/{userId}")
+    public ResponseEntity<DetailUserResponse> update(@PathVariable Long userId, @RequestBody
+    UpdateUserRequest request) {
+        DetailUserResponse response = userService.updateUser(userId, request);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/programmers/smrtstore/domain/user/presentation/controller/UserController.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/presentation/controller/UserController.java
@@ -6,6 +6,7 @@ import com.programmers.smrtstore.domain.user.presentation.dto.res.DetailUserResp
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -36,7 +37,13 @@ public class UserController {
     @PostMapping("/{userId}")
     public ResponseEntity<DetailUserResponse> update(@PathVariable Long userId, @RequestBody
     UpdateUserRequest request) {
-        DetailUserResponse response = userService.updateUser(userId, request);
+        DetailUserResponse response = userService.update(userId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{userId}")
+    public ResponseEntity<DetailUserResponse> withdraw(@PathVariable Long userId) {
+        DetailUserResponse response = userService.withdraw(userId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/programmers/smrtstore/domain/user/presentation/controller/UserController.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/presentation/controller/UserController.java
@@ -34,16 +34,16 @@ public class UserController {
         return ResponseEntity.ok(response);
     }
 
-    @PostMapping("/{userId}")
-    public ResponseEntity<DetailUserResponse> update(@PathVariable Long userId, @RequestBody
+    @PostMapping("/update")
+    public ResponseEntity<DetailUserResponse> update(@RequestBody
     UpdateUserRequest request) {
-        DetailUserResponse response = userService.update(userId, request);
+        DetailUserResponse response = userService.update(request);
         return ResponseEntity.ok(response);
     }
 
-    @DeleteMapping("/{userId}")
-    public ResponseEntity<DetailUserResponse> withdraw(@PathVariable Long userId) {
-        DetailUserResponse response = userService.withdraw(userId);
+    @DeleteMapping("/withdraw")
+    public ResponseEntity<DetailUserResponse> withdraw() {
+        DetailUserResponse response = userService.withdraw();
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/programmers/smrtstore/domain/user/presentation/controller/UserController.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/presentation/controller/UserController.java
@@ -22,12 +22,6 @@ public class UserController {
 
     private final UserService userService;
 
-    @GetMapping("/{userId}")
-    public ResponseEntity<DetailUserResponse> findByUserId(@PathVariable Long userId) {
-        DetailUserResponse response = userService.findByUserId(userId);
-        return ResponseEntity.ok(response);
-    }
-
     @GetMapping
     public ResponseEntity<DetailUserResponse> me() {
         DetailUserResponse response = userService.getUserInfo();

--- a/src/main/java/com/programmers/smrtstore/domain/user/presentation/dto/req/LoginRequest.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/presentation/dto/req/LoginRequest.java
@@ -1,11 +1,9 @@
 package com.programmers.smrtstore.domain.user.presentation.dto.req;
 
 import jakarta.validation.constraints.NotEmpty;
-import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@Builder
 public class LoginRequest {
 
     @NotEmpty

--- a/src/main/java/com/programmers/smrtstore/domain/user/presentation/dto/req/SignUpUserRequest.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/presentation/dto/req/SignUpUserRequest.java
@@ -9,11 +9,9 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
-import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@Builder
 public class SignUpUserRequest {
 
     @NotBlank

--- a/src/main/java/com/programmers/smrtstore/domain/user/presentation/dto/req/SignUpUserRequest.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/presentation/dto/req/SignUpUserRequest.java
@@ -57,4 +57,7 @@ public class SignUpUserRequest {
 
     @NotNull
     boolean membershipYN;
+
+    @NotNull
+    boolean repurchaseYN;
 }

--- a/src/main/java/com/programmers/smrtstore/domain/user/presentation/dto/req/SignUpUserRequest.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/presentation/dto/req/SignUpUserRequest.java
@@ -1,7 +1,11 @@
 package com.programmers.smrtstore.domain.user.presentation.dto.req;
 
+import static com.programmers.smrtstore.domain.user.domain.entity.Auth.toAuth;
+
+import com.programmers.smrtstore.domain.user.domain.entity.Auth;
 import com.programmers.smrtstore.domain.user.domain.entity.Gender;
 import com.programmers.smrtstore.domain.user.domain.entity.Role;
+import com.programmers.smrtstore.domain.user.domain.entity.User;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -10,6 +14,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Getter
 public class SignUpUserRequest {
@@ -60,4 +65,20 @@ public class SignUpUserRequest {
 
     @NotNull
     boolean repurchaseYN;
+
+    public User toUser(PasswordEncoder passwordEncoder) {
+        Auth auth = toAuth(loginId, password, passwordEncoder);
+        return User.builder()
+            .auth(auth)
+            .age(age)
+            .birth(birth)
+            .email(email)
+            .gender(gender)
+            .role(role)
+            .phone(phone)
+            .marketingAgree(marketingAgree)
+            .nickName(nickName)
+            .thumbnail(thumbnail)
+            .build();
+    }
 }

--- a/src/main/java/com/programmers/smrtstore/domain/user/presentation/dto/req/UpdateUserRequest.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/presentation/dto/req/UpdateUserRequest.java
@@ -53,4 +53,7 @@ public class UpdateUserRequest {
 
     @NotNull
     boolean membershipYN;
+
+    @NotNull
+    boolean repurchaseYN;
 }

--- a/src/main/java/com/programmers/smrtstore/domain/user/presentation/dto/req/UpdateUserRequest.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/presentation/dto/req/UpdateUserRequest.java
@@ -1,5 +1,56 @@
 package com.programmers.smrtstore.domain.user.presentation.dto.req;
 
+import com.programmers.smrtstore.domain.user.domain.entity.Gender;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
 public class UpdateUserRequest {
 
+    @NotBlank
+    @Size(max = 12, min = 4, message = "Login Id는 4~12자리여야 합니다.")
+    @Pattern(regexp = "^[a-zA-Z0-9]+$", message = "Login ID는 영문자 또는 숫자만 가능합니다.")
+    String loginId;
+
+    @NotBlank
+    @Size(min = 8, max = 20, message = "비밀번호는 8~20자리여야 합니다.")
+    @Pattern(regexp = "^[a-zA-Z0-9!@#$%^&*()_+\\-=\\[\\]{};':\",./<>?\\\\|]+$",
+        message = "비밀번호는 영문자, 숫자, 특수문자만 허용됩니다.")
+    String password;
+
+    @Min(value = 7, message = "나이는 7살 이상이어야 합니다.")
+    @Max(value = 200, message = "나이는 200살 이하여야 합니다.")
+    Integer age;
+
+    @NotBlank
+    @Size(min = 1, max = 10, message = "별명은 1~10자여야 합니다.")
+    String nickName;
+
+    @NotBlank @Email
+    String email;
+
+    @NotBlank
+    @Pattern(regexp = "^01(?:0|1|[6-9])[0-9]{7,8}$", message = "올바른 휴대폰 번호 형식이 아닙니다.")
+    String phone;
+
+    @NotBlank
+    @Pattern(regexp = "^\\d{8}$", message = "올바른 생년월일 형식이 아닙니다.")
+    String birth;
+
+    @NotNull
+    Gender gender;
+
+    String thumbnail;
+
+    @NotNull
+    boolean marketingAgree;
+
+    @NotNull
+    boolean membershipYN;
 }

--- a/src/main/java/com/programmers/smrtstore/domain/user/presentation/dto/res/DetailAuthResponse.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/presentation/dto/res/DetailAuthResponse.java
@@ -1,0 +1,28 @@
+package com.programmers.smrtstore.domain.user.presentation.dto.res;
+
+import com.programmers.smrtstore.domain.auth.jwt.JwtAuthentication;
+import com.programmers.smrtstore.domain.user.domain.entity.Role;
+import com.programmers.smrtstore.domain.user.domain.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class DetailAuthResponse {
+
+    private String accessToken;
+    private String refreshToken;
+    private String username;
+    private Role role;
+
+    public static DetailAuthResponse toDetailUserResponse(JwtAuthentication authentication,
+        User user) {
+        return DetailAuthResponse.builder()
+            .accessToken(authentication.getAccessToken())
+            .refreshToken(authentication.getRefreshToken())
+            .role(user.getRole())
+            .build();
+    }
+}

--- a/src/main/java/com/programmers/smrtstore/domain/user/presentation/dto/res/DetailAuthResponse.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/presentation/dto/res/DetailAuthResponse.java
@@ -17,7 +17,7 @@ public class DetailAuthResponse {
     private String username;
     private Role role;
 
-    public static DetailAuthResponse toDetailUserResponse(JwtAuthentication authentication,
+    public static DetailAuthResponse toDetailAuthResponse(JwtAuthentication authentication,
         User user) {
         return DetailAuthResponse.builder()
             .username(user.getAuth().getLoginId())

--- a/src/main/java/com/programmers/smrtstore/domain/user/presentation/dto/res/DetailAuthResponse.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/presentation/dto/res/DetailAuthResponse.java
@@ -20,6 +20,7 @@ public class DetailAuthResponse {
     public static DetailAuthResponse toDetailUserResponse(JwtAuthentication authentication,
         User user) {
         return DetailAuthResponse.builder()
+            .username(user.getAuth().getLoginId())
             .accessToken(authentication.getAccessToken())
             .refreshToken(authentication.getRefreshToken())
             .role(user.getRole())

--- a/src/main/java/com/programmers/smrtstore/domain/user/presentation/dto/res/DetailUserResponse.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/presentation/dto/res/DetailUserResponse.java
@@ -61,7 +61,7 @@ public class DetailUserResponse {
             user.getPoint(),
             user.isMarketingAgree(),
             user.isMembershipYN(),
-            user.isRepurchase(),
+            user.isRepurchaseYN(),
             user.getUpdatedAt(),
             user.getCreatedAt(),
             user.getDeletedAt()

--- a/src/main/java/com/programmers/smrtstore/domain/user/presentation/dto/res/DetailUserResponse.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/presentation/dto/res/DetailUserResponse.java
@@ -1,28 +1,70 @@
 package com.programmers.smrtstore.domain.user.presentation.dto.res;
 
-import com.programmers.smrtstore.domain.auth.jwt.JwtAuthentication;
+import com.programmers.smrtstore.domain.user.domain.entity.Gender;
 import com.programmers.smrtstore.domain.user.domain.entity.Role;
 import com.programmers.smrtstore.domain.user.domain.entity.User;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 
-@Builder
 @Getter
 @AllArgsConstructor
 public class DetailUserResponse {
 
-    private String accessToken;
-    private String refreshToken;
-    private String username;
+    private Long id;
+
+    private String loginId;
+
+    private Integer age;
+
+    private String nickName;
+
+    private String email;
+
+    private String phone;
+
+    private String birth;
+
+    private Gender gender;
+
+    private String thumbnail;
+
     private Role role;
 
-    public static DetailUserResponse toDetailUserResponse(JwtAuthentication authentication,
-        User user) {
-        return DetailUserResponse.builder()
-            .accessToken(authentication.getAccessToken())
-            .refreshToken(authentication.getRefreshToken())
-            .role(user.getRole())
-            .build();
+    private Integer point;
+
+    private boolean marketingAgree;
+
+    private boolean membershipYN;
+
+    private boolean repurchase;
+
+    private LocalDateTime updatedAt;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime deletedAt;
+
+
+    public static DetailUserResponse toDetailUserResponse(User user) {
+        return new DetailUserResponse(
+            user.getId(),
+            user.getAuth().getLoginId(),
+            user.getAge(),
+            user.getNickName(),
+            user.getEmail(),
+            user.getPhone(),
+            user.getBirth(),
+            user.getGender(),
+            user.getThumbnail(),
+            user.getRole(),
+            user.getPoint(),
+            user.isMarketingAgree(),
+            user.isMembershipYN(),
+            user.isRepurchase(),
+            user.getUpdatedAt(),
+            user.getCreatedAt(),
+            user.getDeletedAt()
+        );
     }
 }

--- a/src/main/java/com/programmers/smrtstore/domain/user/presentation/dto/res/SignUpUserResponse.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/presentation/dto/res/SignUpUserResponse.java
@@ -11,6 +11,8 @@ import lombok.Getter;
 @Getter
 public class SignUpUserResponse {
 
+    Long id;
+
     String loginId;
 
     String password;
@@ -47,6 +49,7 @@ public class SignUpUserResponse {
 
     public static SignUpUserResponse toSignUpUserResponse(User user) {
         return SignUpUserResponse.builder()
+            .id(user.getId())
             .age(user.getAge())
             .birth(user.getBirth())
             .createdTime(user.getCreatedAt())

--- a/src/main/java/com/programmers/smrtstore/domain/user/presentation/dto/res/SignUpUserResponse.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/presentation/dto/res/SignUpUserResponse.java
@@ -35,6 +35,8 @@ public class SignUpUserResponse {
 
     boolean membershipYN;
 
+    boolean repurchaseYN;
+
     Integer point;
 
     LocalDateTime updatedTime;
@@ -61,6 +63,7 @@ public class SignUpUserResponse {
             .role(user.getRole())
             .phone(user.getPhone())
             .thumbnail(user.getThumbnail())
+            .repurchaseYN(user.isRepurchaseYN())
             .build();
     }
 }


### PR DESCRIPTION
## Service, Controller
- me : 토큰으로 회원 정보 조회
- findByUserId : user id로 회원 정보 조회
- update : 회원 정보 수정
- withdraw : 회원 탈퇴

## 얘기해보고 싶은 사항
- builder을 사용하지 않고 정적팩토리 메서드로 생성자로 객체를 생성했습니다. 그런데 이러면 만약 고객이 상품을 재구매할 때repuchaseYN의 상태를 true로 바꿀 경우, user의 다른 모든 정보도 모두 다시 넣어주거나, 다른 정보들은 null로 보내고 객체를 변경할 경우 null 체크를 해줘야 합니다. 필드가 너무 많아 코드가 다소 복잡해질 것 같은데, 어떻게 생각하는지 궁금합니다.

- 조회, 수정, 탈퇴 시 인증이 필요하다고 생각해 토큰을 이용해 사용자 정보를 등록하고 가져오도록 구현했습니다. 이때 인증을 위한 객체들 생성을 수정, 삭제 시마다 해줘야할지 service에 생성해놓고 사용해야할지에 대한 의견이 궁금합니다.

- findByUserId가 필요한지에 대한 생각이 궁금합니다.

## 요청사항
- gradle guava 삭제..!