### PR TITLE
[FEAT] orderSheet entity 추가와 order 관련 entity 정리

### DIFF
--- a/src/main/java/com/programmers/smrtstore/core/base/TimestampBaseEntity.java
+++ b/src/main/java/com/programmers/smrtstore/core/base/TimestampBaseEntity.java
@@ -1,0 +1,24 @@
+package com.programmers.smrtstore.core.base;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Getter
+@MappedSuperclass
+public abstract class TimestampBaseEntity {
+
+    @CreationTimestamp
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+}

--- a/src/main/java/com/programmers/smrtstore/domain/order/domain/entity/DeliveryInfo.java
+++ b/src/main/java/com/programmers/smrtstore/domain/order/domain/entity/DeliveryInfo.java
@@ -1,6 +1,9 @@
 package com.programmers.smrtstore.domain.order.domain.entity;
 
+import com.programmers.smrtstore.domain.order.domain.entity.vo.DeliveryAddress;
+import com.programmers.smrtstore.domain.order.domain.entity.vo.ReceiverInfo;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -14,27 +17,18 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "delivery_info_TB")
 @Entity
-public class ShippingInfo {
+public class DeliveryInfo {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")
     private Long id;
 
-    @Column(name = "address_1depth")
-    private String address1depth;
+    @Embedded
+    private DeliveryAddress deliveryAddress;
 
-    @Column(name = "address_2depth")
-    private String address2depth;
-
-    @Column(name = "zip_code")
-    private String zipCode;
-
-    @Column(name = "receiver_name")
-    private String receiverName;
-
-    @Column(name = "receiver_phone")
-    private String receiverPhone;
+    @Embedded
+    private ReceiverInfo receiverInfo;
 
     @Column(name = "delivery_request")
     private String deliveryRequest;

--- a/src/main/java/com/programmers/smrtstore/domain/order/domain/entity/Order.java
+++ b/src/main/java/com/programmers/smrtstore/domain/order/domain/entity/Order.java
@@ -2,13 +2,20 @@ package com.programmers.smrtstore.domain.order.domain.entity;
 
 import com.programmers.smrtstore.domain.order.domain.entity.enums.OrderStatus;
 import com.programmers.smrtstore.domain.order.domain.entity.enums.PaymentMethod;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,20 +27,37 @@ import lombok.NoArgsConstructor;
 public class Order {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")
-    private Long id;
+    private String id;
 
-    private Long userId;
+    @OneToOne
+    @JoinColumn(name = "order_sheet_id")
+    private OrderSheet orderSheet;
 
-    private Long shippingInfoId;
-
-    private LocalDateTime orderDate;
-
+    @Column(name = "order_status")
+    @Enumerated(EnumType.STRING)
     private OrderStatus orderStatus;
 
+    @Column(name = "payment_method")
+    @Enumerated(EnumType.STRING)
     private PaymentMethod paymentMethod;
 
+    @Column(name = "total_price")
     private Integer totalPrice;
+
+    @Column(name = "order_date")
+    private LocalDateTime orderDate;
+
+    @Column(name = "payment_date")
+    private LocalDateTime paymentDate;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
 
 }

--- a/src/main/java/com/programmers/smrtstore/domain/order/domain/entity/Order.java
+++ b/src/main/java/com/programmers/smrtstore/domain/order/domain/entity/Order.java
@@ -1,21 +1,19 @@
 package com.programmers.smrtstore.domain.order.domain.entity;
 
+import com.programmers.smrtstore.core.base.TimestampBaseEntity;
 import com.programmers.smrtstore.domain.order.domain.entity.enums.OrderStatus;
-import com.programmers.smrtstore.domain.order.domain.entity.enums.PaymentMethod;
+import com.programmers.smrtstore.domain.order.domain.entity.vo.PaymentInfo;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,7 +22,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "order_TB")
 @Entity
-public class Order {
+public class Order extends TimestampBaseEntity {
 
     @Id
     @Column(name = "id")
@@ -38,26 +36,17 @@ public class Order {
     @Enumerated(EnumType.STRING)
     private OrderStatus orderStatus;
 
-    @Column(name = "payment_method")
-    @Enumerated(EnumType.STRING)
-    private PaymentMethod paymentMethod;
-
     @Column(name = "total_price")
     private Integer totalPrice;
 
     @Column(name = "order_date")
     private LocalDateTime orderDate;
 
-    @Column(name = "payment_date")
-    private LocalDateTime paymentDate;
+    @OneToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "delivery_info_id")
+    private DeliveryInfo deliveryInfo;
 
-    @Column(name = "created_at")
-    private LocalDateTime createdAt;
-
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
-
-    @Column(name = "deleted_at")
-    private LocalDateTime deletedAt;
+    @Embedded
+    private PaymentInfo paymentInfo;
 
 }

--- a/src/main/java/com/programmers/smrtstore/domain/order/domain/entity/OrderSheet.java
+++ b/src/main/java/com/programmers/smrtstore/domain/order/domain/entity/OrderSheet.java
@@ -1,6 +1,7 @@
 package com.programmers.smrtstore.domain.order.domain.entity;
 
-import com.programmers.smrtstore.domain.product.domain.entity.Product;
+import com.programmers.smrtstore.domain.user.domain.entity.User;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -9,16 +10,20 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "ordered_product_TB")
+@Table(name = "order_sheet_TB")
 @Entity
-public class OrderedProduct {
+public class OrderSheet {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,17 +31,19 @@ public class OrderedProduct {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="order_sheet_id")
-    private OrderSheet orderSheet;
+    @JoinColumn(name = "user_id", insertable = false, updatable = false)
+    private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="product_id")
-    private Product product;
+    @OneToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "shipping_info_id")
+    private ShippingInfo shippingInfo;
 
-    @Column(name = "quantity")
-    private Integer quantity;
+    @OneToMany(mappedBy = "orderSheet", cascade = CascadeType.ALL)
+    private List<OrderedProduct> orderedProducts;
 
-    @Column(name = "total_price")
     private Integer total_price;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
 
 }

--- a/src/main/java/com/programmers/smrtstore/domain/order/domain/entity/OrderSheet.java
+++ b/src/main/java/com/programmers/smrtstore/domain/order/domain/entity/OrderSheet.java
@@ -41,8 +41,6 @@ public class OrderSheet {
     @OneToMany(mappedBy = "orderSheet", cascade = CascadeType.ALL)
     private List<OrderedProduct> orderedProducts;
 
-    private Integer total_price;
-
     @Column(name = "created_at")
     private LocalDateTime createdAt;
 

--- a/src/main/java/com/programmers/smrtstore/domain/order/domain/entity/OrderSheet.java
+++ b/src/main/java/com/programmers/smrtstore/domain/order/domain/entity/OrderSheet.java
@@ -31,7 +31,7 @@ public class OrderSheet {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", insertable = false, updatable = false)
+    @JoinColumn(name = "user_id", updatable = false)
     private User user;
 
     @OneToOne(cascade = CascadeType.ALL)

--- a/src/main/java/com/programmers/smrtstore/domain/order/domain/entity/OrderSheet.java
+++ b/src/main/java/com/programmers/smrtstore/domain/order/domain/entity/OrderSheet.java
@@ -18,6 +18,7 @@ import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -34,13 +35,10 @@ public class OrderSheet {
     @JoinColumn(name = "user_id", updatable = false)
     private User user;
 
-    @OneToOne(cascade = CascadeType.ALL)
-    @JoinColumn(name = "shipping_info_id")
-    private ShippingInfo shippingInfo;
-
     @OneToMany(mappedBy = "orderSheet", cascade = CascadeType.ALL)
     private List<OrderedProduct> orderedProducts;
 
+    @CreationTimestamp
     @Column(name = "created_at")
     private LocalDateTime createdAt;
 

--- a/src/main/java/com/programmers/smrtstore/domain/order/domain/entity/OrderedProduct.java
+++ b/src/main/java/com/programmers/smrtstore/domain/order/domain/entity/OrderedProduct.java
@@ -37,6 +37,6 @@ public class OrderedProduct {
     private Integer quantity;
 
     @Column(name = "total_price")
-    private Integer total_price;
+    private Integer totalPrice;
 
 }

--- a/src/main/java/com/programmers/smrtstore/domain/order/domain/entity/ShippingInfo.java
+++ b/src/main/java/com/programmers/smrtstore/domain/order/domain/entity/ShippingInfo.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "shipping_info_TB")
+@Table(name = "delivery_info_TB")
 @Entity
 public class ShippingInfo {
 
@@ -21,18 +21,25 @@ public class ShippingInfo {
     @Column(name = "id")
     private Long id;
 
-    private String address_1depth;
+    @Column(name = "address_1depth")
+    private String address1depth;
 
-    private String address_2depth;
+    @Column(name = "address_2depth")
+    private String address2depth;
 
+    @Column(name = "zip_code")
     private String zipCode;
 
+    @Column(name = "receiver_name")
     private String receiverName;
 
+    @Column(name = "receiver_phone")
     private String receiverPhone;
 
-    private String shippingRequest;
+    @Column(name = "delivery_request")
+    private String deliveryRequest;
 
-    private Integer shippingPrice;
+    @Column(name = "delivery_price")
+    private Integer deliveryPrice;
 
 }

--- a/src/main/java/com/programmers/smrtstore/domain/order/domain/entity/ShippingInfo.java
+++ b/src/main/java/com/programmers/smrtstore/domain/order/domain/entity/ShippingInfo.java
@@ -39,7 +39,7 @@ public class ShippingInfo {
     @Column(name = "delivery_request")
     private String deliveryRequest;
 
-    @Column(name = "delivery_price")
-    private Integer deliveryPrice;
+    @Column(name = "delivery_fee")
+    private Integer deliveryFee;
 
 }

--- a/src/main/java/com/programmers/smrtstore/domain/order/domain/entity/enums/OrderStatus.java
+++ b/src/main/java/com/programmers/smrtstore/domain/order/domain/entity/enums/OrderStatus.java
@@ -1,5 +1,15 @@
 package com.programmers.smrtstore.domain.order.domain.entity.enums;
 
 public enum OrderStatus {
-    PAYMENT_WAITING, PAYMENT_COMPLETED, PREPARING_FOR_SHIPMENT, SHIPPED, DELIVERED, CANCELLED, PURCHASE_CONFIRMED, REFUND_REQUESTED, REFUND_COMPLETED
+    PAYMENT_WAITING, // 결제 대기
+    PAYMENT_COMPLETED, // 결제 완료
+    DELIVERY_PREPARING, // 상품 준비중
+    DELIVERING_BEFORE, // 배송 준비중
+    DELIVERING, // 배송중
+    DELIVERED, // 배송 완료
+    CANCELLED, // 주문 취소
+    PURCHASE_CONFIRMED, // 구매 확정
+    REFUND_REQUESTED, // 환불 요청
+    REFUND_COMPLETED, // 환불 완료
+    CANCELLED_BY_NO_PAYMENT // 미결제 주문 취소
 }

--- a/src/main/java/com/programmers/smrtstore/domain/order/domain/entity/vo/DeliveryAddress.java
+++ b/src/main/java/com/programmers/smrtstore/domain/order/domain/entity/vo/DeliveryAddress.java
@@ -1,0 +1,22 @@
+package com.programmers.smrtstore.domain.order.domain.entity.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DeliveryAddress {
+
+    @Column(name = "address_1depth")
+    private String address1depth;
+
+    @Column(name = "address_2depth")
+    private String address2depth;
+
+    @Column(name = "zip_code")
+    private String zipCode;
+}

--- a/src/main/java/com/programmers/smrtstore/domain/order/domain/entity/vo/PaymentInfo.java
+++ b/src/main/java/com/programmers/smrtstore/domain/order/domain/entity/vo/PaymentInfo.java
@@ -1,0 +1,24 @@
+package com.programmers.smrtstore.domain.order.domain.entity.vo;
+
+import com.programmers.smrtstore.domain.order.domain.entity.enums.PaymentMethod;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PaymentInfo {
+
+    @Column(name = "payment_method")
+    @Enumerated(EnumType.STRING)
+    private PaymentMethod paymentMethod;
+
+    @Column(name = "payment_date")
+    private LocalDateTime paymentDate;
+}

--- a/src/main/java/com/programmers/smrtstore/domain/order/domain/entity/vo/ReceiverInfo.java
+++ b/src/main/java/com/programmers/smrtstore/domain/order/domain/entity/vo/ReceiverInfo.java
@@ -1,0 +1,19 @@
+package com.programmers.smrtstore.domain.order.domain.entity.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReceiverInfo {
+
+    @Column(name = "receiver_name")
+    private String receiverName;
+
+    @Column(name = "receiver_phone")
+    private String receiverPhone;
+}


### PR DESCRIPTION
## 변경 사항
1. orderSheet 관련 entity 추가와 order 연관관계 정리
<img width="1065" alt="스크린샷 2023-12-29 오전 12 39 17" src="https://github.com/smRt-Egg/BE-05-smRt-store/assets/78072370/1c28d928-61d0-435e-9e62-fec1eda87d30">


2. DDD 적용 VO 처리
- DeliveryAddress
- PaymentInfo
- ReceiverInfo

3. date 관련 base Entity 추가
- createdAt
- deletedAt
- updatesAt


close #60 