### PR TITLE
Feat/#110 user annotation

### DIFF
--- a/src/main/java/com/programmers/smrtstore/common/annotation/UserId.java
+++ b/src/main/java/com/programmers/smrtstore/common/annotation/UserId.java
@@ -1,0 +1,13 @@
+package com.programmers.smrtstore.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+// TODO: 테스트 코드 작성
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UserId {
+
+}

--- a/src/main/java/com/programmers/smrtstore/common/base/TimestampBaseEntity.java
+++ b/src/main/java/com/programmers/smrtstore/common/base/TimestampBaseEntity.java
@@ -1,4 +1,4 @@
-package com.programmers.smrtstore.core.base;
+package com.programmers.smrtstore.common.base;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;

--- a/src/main/java/com/programmers/smrtstore/common/resolver/UserIdResolver.java
+++ b/src/main/java/com/programmers/smrtstore/common/resolver/UserIdResolver.java
@@ -1,0 +1,32 @@
+package com.programmers.smrtstore.common.resolver;
+
+import static com.programmers.smrtstore.core.properties.ErrorCode.MISSING_CREDENTIALS;
+
+import com.programmers.smrtstore.common.annotation.UserId;
+import com.programmers.smrtstore.domain.auth.exception.AuthException;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class UserIdResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterAnnotation(UserId.class) != null;
+    }
+
+    @Override
+    public Object resolveArgument(
+        MethodParameter parameter, ModelAndViewContainer mavContainer,
+        NativeWebRequest webRequest, WebDataBinderFactory binderFactory
+    ) {
+        Long userId = (Long) webRequest.getAttribute("userId", RequestAttributes.SCOPE_REQUEST);
+        if (userId == null) {
+            throw new AuthException(MISSING_CREDENTIALS);
+        }
+        return userId;
+    }
+}

--- a/src/main/java/com/programmers/smrtstore/core/config/WebConfiguration.java
+++ b/src/main/java/com/programmers/smrtstore/core/config/WebConfiguration.java
@@ -1,0 +1,16 @@
+package com.programmers.smrtstore.core.config;
+
+import com.programmers.smrtstore.common.resolver.UserIdResolver;
+import java.util.List;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfiguration implements WebMvcConfigurer {
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new UserIdResolver());
+    }
+}

--- a/src/main/java/com/programmers/smrtstore/core/properties/ErrorCode.java
+++ b/src/main/java/com/programmers/smrtstore/core/properties/ErrorCode.java
@@ -5,6 +5,7 @@ import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.OK;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -34,6 +35,8 @@ public enum ErrorCode {
     COUPON_ALREADY_USED(BAD_REQUEST, "이미 사용 완료한 쿠폰입니다."),
     COUPON_NOT_AVAILABLE(BAD_REQUEST, "유효하지 않은 쿠폰입니다."),
     ORDER_PRICE_NOT_ENOUGH(BAD_REQUEST, "쿠폰의 최소 주문 금액 미만입니다."),
+    // 401
+    MISSING_CREDENTIALS(UNAUTHORIZED, "사용자의 인증 정보를 찾을 수 없습니다."),
     // 404
     USER_NOT_FOUND(NOT_FOUND, "사용자를 찾을 수 없습니다."),
     ORDER_NOT_FOUND(NOT_FOUND, "주문을 찾을 수 없습니다."),

--- a/src/main/java/com/programmers/smrtstore/domain/auth/exception/AuthException.java
+++ b/src/main/java/com/programmers/smrtstore/domain/auth/exception/AuthException.java
@@ -6,7 +6,7 @@ import com.programmers.smrtstore.exception.exceptionClass.CustomException;
 public class AuthException extends CustomException {
 
     public AuthException(ErrorCode errorCode) {
-        super(errorCode, null);
+        super(errorCode);
     }
 
     public AuthException(ErrorCode errorCode,

--- a/src/main/java/com/programmers/smrtstore/domain/order/domain/entity/Order.java
+++ b/src/main/java/com/programmers/smrtstore/domain/order/domain/entity/Order.java
@@ -1,6 +1,6 @@
 package com.programmers.smrtstore.domain.order.domain.entity;
 
-import com.programmers.smrtstore.core.base.TimestampBaseEntity;
+import com.programmers.smrtstore.common.base.TimestampBaseEntity;
 import com.programmers.smrtstore.domain.order.domain.entity.enums.OrderStatus;
 import com.programmers.smrtstore.domain.order.domain.entity.vo.PaymentInfo;
 import jakarta.persistence.CascadeType;

--- a/src/main/java/com/programmers/smrtstore/domain/order/infrastructure/OrderJpaRepository.java
+++ b/src/main/java/com/programmers/smrtstore/domain/order/infrastructure/OrderJpaRepository.java
@@ -8,24 +8,60 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface OrderJpaRepository extends JpaRepository<Order, Long>, OrderRepositoryCustom {
 
-    // TODO: user 가 탈퇴한 경우 어떻게 처리할 것인가?
+    // TODO: user 가 탈퇴한 경우 해당 메소드 어떻게 처리할 것인가?
+    /**
+     * 단일 Order를 조회합니다. 이 메소드는 삭제 된 Order 엔티티는 제외 하고 반환합니다. 이 메소드는 'orderSheet'와 'orderSheet 의 user'
+     * 필드를 Eager로 로딩합니다.
+     *
+     * @param orderId 조회하고자 하는 Order의 ID입니다.
+     * @return Optional<Order> - 해당 ID를 가진 Order 객체. 만약 Order가 존재하지 않거나 'deletedAt'이 null이 아닐 경우, 비어
+     * 있는 Optional을 반환합니다.
+     */
     @EntityGraph(attributePaths = {"orderSheet", "orderSheet.user"})
     @Query("SELECT o FROM Order o WHERE o.id = :orderId AND o.deletedAt IS NULL")
     Optional<Order> findByIdWithOrderSheetAndUser(Long orderId);
 
+    /**
+     * 단일 Order를 조회합니다. 이 메소드는 삭제 된 Order 엔티티는 제외 하고 반환합니다. 이 메소드는 'orderSheet' 필드를 Eager로 로딩합니다.
+     *
+     * @param orderId 조회하고자 하는 Order의 ID입니다.
+     * @return Optional<Order> - 해당 ID를 가진 Order 객체. 만약 Order가 존재하지 않거나 'deletedAt'이 null이 아닐 경우, 비어
+     * 있는 Optional을 반환합니다.
+     */
     @EntityGraph(attributePaths = {"orderSheet"})
     @Query("SELECT o FROM Order o WHERE o.id = :orderId AND o.deletedAt IS NULL")
     Optional<Order> findByIdWithOrderSheet(Long orderId);
 
+    /**
+     * 단일 Order를 조회합니다. 이 메소드는 삭제 된 Order 엔티티는 제외 하고 반환합니다.
+     *
+     * @param orderId 조회하고자 하는 Order의 ID입니다.
+     * @return Optional<Order> - 해당 ID를 가진 Order 객체. 만약 Order가 존재하지 않거나 'deletedAt'이 null이 아닐 경우, 비어
+     * 있는 Optional을 반환합니다.
+     */
     @Override
     @Query("SELECT o FROM Order o WHERE o.id = :orderId AND o.deletedAt IS NULL")
     Optional<Order> findById(Long orderId);
 
+    /**
+     * 단일 Order를 조회합니다. 이 메소드는 삭제 된 Order 엔티티도 포함하여 결과를 반환합니다. 이 메소드는 'orderSheet' 필드를 Eager로
+     * 로딩합니다.
+     *
+     * @param orderId 조회하고자 하는 Order의 ID입니다.
+     * @return Optional<Order> - 해당 ID를 가진 Order 객체. 만약 Order가 존재하지 않으면, 비어 있는 Optional을 반환합니다.
+     */
     @EntityGraph(attributePaths = {"orderSheet"})
     @Query("SELECT o FROM Order o WHERE o.id = :orderId")
     Optional<Order> findByIdWithOrderSheetIncludeDeleted(Long orderId);
 
-    @Query("SELECT o FROM Order o WHERE o.id = :orderIdL")
-    Optional<Order> findByIdIncludeDeleted(Long orderIdL);
+    /**
+     * 단일 Order를 조회합니다. 이 메소드는 삭제 된 Order 엔티티도 포함하여 결과를 반환합니다.
+     *
+     * @param orderId 조회하고자 하는 Order의 ID입니다.
+     * @return Optional<Order> - 해당 ID를 가진 Order 객체. 만약 Order가 존재하지 않으면, 비어
+     * 있는 Optional을 반환합니다.
+     */
+    @Query("SELECT o FROM Order o WHERE o.id = :orderId")
+    Optional<Order> findByIdIncludeDeleted(Long orderId);
 
 }

--- a/src/main/java/com/programmers/smrtstore/domain/review/domain/entity/Review.java
+++ b/src/main/java/com/programmers/smrtstore/domain/review/domain/entity/Review.java
@@ -1,6 +1,6 @@
 package com.programmers.smrtstore.domain.review.domain.entity;
 
-import com.programmers.smrtstore.core.base.TimestampBaseEntity;
+import com.programmers.smrtstore.common.base.TimestampBaseEntity;
 import com.programmers.smrtstore.domain.product.domain.entity.Product;
 import com.programmers.smrtstore.domain.user.domain.entity.User;
 import jakarta.persistence.CascadeType;


### PR DESCRIPTION
## 개발 사항
- `@UserId ` 
시큐리티에서 인증 한 userId 를 컨트롤러에서 파라미터로 받을 수 있는 어노테이션 구현

close #110 

이제부터 다른 도메인에서 userId 를 가져올때는

```
@PostMapping
public void 어쩌고함수(@UserId Long userId) {
  ....
}
```

이런식으로 컨트롤러에서 사용해 주세요!

## 특이사항
1. UserId 가 들어가있지 않은 경우에는 AuthException 이 발생합니다.
2. Long 타입이 틀릴 시에는 타입 에러가 발생합니다.
3. 서비스에서는 userId 로 유저 존재 여부를 다시 한번 확인해 주세요.
4. 테스트 작성을 하지 못했습니다. 시큐팀과 이야기 해서 추후 작성 예정!