### PR TITLE
Feat/#136 user shipping address 수정 정보 조회, 수정, 삭제

### DIFF
--- a/src/main/java/com/programmers/smrtstore/core/properties/ErrorCode.java
+++ b/src/main/java/com/programmers/smrtstore/core/properties/ErrorCode.java
@@ -48,6 +48,7 @@ public enum ErrorCode {
     CART_ALREADY_EXIST(BAD_REQUEST, "이미 장바구니에 담긴 상품입니다."),
     COUPON_PERCENT_EXCEED(BAD_REQUEST,"쿠폰의 퍼센트 할인값은 100% 를 초과할 수 없습니다."),
     EXCEEDED_MAXIMUM_NUMBER_OF_SHIPPING_ADDRESS(BAD_REQUEST, "배송지 수가 이미 최대입니다."),
+    DELETE_DEFAULT_SHIPPING(BAD_REQUEST, "다른 배송지를 기본 배송지로 변경 후 삭제해주세요."),
     // 401
     MISSING_CREDENTIALS(UNAUTHORIZED, "사용자의 인증 정보를 찾을 수 없습니다."),
     SECURITY_UNAUTHORIZED(UNAUTHORIZED, "인증 정보가 유효하지 않습니다"),

--- a/src/main/java/com/programmers/smrtstore/core/properties/ErrorCode.java
+++ b/src/main/java/com/programmers/smrtstore/core/properties/ErrorCode.java
@@ -65,6 +65,7 @@ public enum ErrorCode {
     REVIEW_NOT_FOUND(NOT_FOUND, "리뷰를 찾을 수 없습니다."),
     REVIEW_LIKE_NOT_FOUND(NOT_FOUND, "리뷰 좋아요를 찾을 수 없습니다."),
     CART_NOT_FOUND(NOT_FOUND, "장바구니를 찾을 수 없습니다."),
+    SHIPPING_ADDRESS_NOT_FOUND(NOT_FOUND, "배송지를 찾을수 없습니다."),
     // 409
     DUPLICATE_USERNAME(CONFLICT, "이미 존재하는 아이디입니다. 다른 아이디를 이용해 주세요."),
     DUPLICATE_SHIPPING_ADDRESS(CONFLICT, "동일한 배송지가 존재합니다. 수정 후 다시 시도해주세요."),

--- a/src/main/java/com/programmers/smrtstore/core/properties/ErrorCode.java
+++ b/src/main/java/com/programmers/smrtstore/core/properties/ErrorCode.java
@@ -48,7 +48,7 @@ public enum ErrorCode {
     CART_ALREADY_EXIST(BAD_REQUEST, "이미 장바구니에 담긴 상품입니다."),
     COUPON_PERCENT_EXCEED(BAD_REQUEST,"쿠폰의 퍼센트 할인값은 100% 를 초과할 수 없습니다."),
     EXCEEDED_MAXIMUM_NUMBER_OF_SHIPPING_ADDRESS(BAD_REQUEST, "배송지 수가 이미 최대입니다."),
-    DELETE_DEFAULT_SHIPPING(BAD_REQUEST, "다른 배송지를 기본 배송지로 변경 후 삭제해주세요."),
+    DEFAULT_SHIPPING_NOT_DELETABLE(BAD_REQUEST, "다른 배송지를 기본 배송지로 변경 후 삭제해주세요."),
     // 401
     MISSING_CREDENTIALS(UNAUTHORIZED, "사용자의 인증 정보를 찾을 수 없습니다."),
     SECURITY_UNAUTHORIZED(UNAUTHORIZED, "인증 정보가 유효하지 않습니다"),

--- a/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
@@ -19,7 +19,6 @@ import com.programmers.smrtstore.domain.user.presentation.dto.res.ProfileUserRes
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -78,8 +77,9 @@ public class UserService {
     private void checkShippingDuplicate(ShippingAddress shippingAddress,
         List<ShippingAddress> shippingAddresses) {
         shippingAddresses.forEach(address -> {
-            if((address.getPhoneNum2() == null && shippingAddress.getPhoneNum2() == null)
-            || (address.getPhoneNum2() != null && shippingAddress.getPhoneNum2() != null && address.getPhoneNum2().equals(shippingAddress.getPhoneNum2()))) {
+            if ((address.getPhoneNum2() == null && shippingAddress.getPhoneNum2() == null)
+                || (address.getPhoneNum2() != null && shippingAddress.getPhoneNum2() != null
+                && address.getPhoneNum2().equals(shippingAddress.getPhoneNum2()))) {
                 if (address.getName().equals(shippingAddress.getName())
                     && address.getRecipient().equals(shippingAddress.getRecipient())
                     && address.getAddress1Depth().equals(shippingAddress.getAddress1Depth())

--- a/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
@@ -1,5 +1,6 @@
 package com.programmers.smrtstore.domain.user.application;
 
+import static com.programmers.smrtstore.core.properties.ErrorCode.DELETE_DEFAULT_SHIPPING;
 import static com.programmers.smrtstore.core.properties.ErrorCode.DUPLICATE_SHIPPING_ADDRESS;
 import static com.programmers.smrtstore.core.properties.ErrorCode.EXCEEDED_MAXIMUM_NUMBER_OF_SHIPPING_ADDRESS;
 import static com.programmers.smrtstore.core.properties.ErrorCode.SHIPPING_ADDRESS_NOT_FOUND;
@@ -123,5 +124,18 @@ public class UserService {
             .orElseThrow(
                 () -> new UserException(SHIPPING_ADDRESS_NOT_FOUND, String.valueOf(shippingId)));
         return CreateShippingResponse.from(shippingAddress);
+    }
+
+    public void deleteShippingAddress(Long shippingId) {
+        ShippingAddress shippingAddress = shippingAddressRepository.findById(shippingId)
+            .orElseThrow(
+                () -> new UserException(SHIPPING_ADDRESS_NOT_FOUND, String.valueOf(shippingId)));
+        checkIsDefault(shippingId, shippingAddress);
+        shippingAddressRepository.delete(shippingAddress);
+    }
+
+    private void checkIsDefault(Long shippingId, ShippingAddress shippingAddress) {
+        if(shippingAddress.isDefaultYn())
+            throw new UserException(DELETE_DEFAULT_SHIPPING, String.valueOf(shippingId));
     }
 }

--- a/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
@@ -12,9 +12,9 @@ import com.programmers.smrtstore.domain.user.domain.entity.User;
 import com.programmers.smrtstore.domain.user.exception.UserException;
 import com.programmers.smrtstore.domain.user.infrastructure.ShippingAddressJpaRepository;
 import com.programmers.smrtstore.domain.user.infrastructure.UserRepository;
-import com.programmers.smrtstore.domain.user.presentation.dto.req.CreateShippingRequest;
+import com.programmers.smrtstore.domain.user.presentation.dto.req.DetailShippingRequest;
 import com.programmers.smrtstore.domain.user.presentation.dto.req.UpdateUserRequest;
-import com.programmers.smrtstore.domain.user.presentation.dto.res.CreateShippingResponse;
+import com.programmers.smrtstore.domain.user.presentation.dto.res.DetailShippingResponse;
 import com.programmers.smrtstore.domain.user.presentation.dto.res.DeliveryAddressBook;
 import com.programmers.smrtstore.domain.user.presentation.dto.res.ProfileUserResponse;
 import java.util.ArrayList;
@@ -53,8 +53,8 @@ public class UserService {
         user.saveDeleteDate();
     }
 
-    public CreateShippingResponse createShippingAddress(Long userId,
-        CreateShippingRequest request) {
+    public DetailShippingResponse createShippingAddress(Long userId,
+        DetailShippingRequest request) {
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new UserException(USER_NOT_FOUND, String.valueOf(userId)));
         List<ShippingAddress> shippingAddresses = user.getShippingAddresses();
@@ -65,7 +65,7 @@ public class UserService {
         user.addShippingAddress(shippingAddress);
         shippingAddressRepository.save(shippingAddress);
 
-        return CreateShippingResponse.from(shippingAddress);
+        return DetailShippingResponse.from(shippingAddress);
     }
 
     private void checkShippingAddressesSize(List<ShippingAddress> shippingAddresses) {
@@ -119,11 +119,11 @@ public class UserService {
         return AggUserShippingInfo.of(defaultShippingAddress, notDefaultShippingAddresses);
     }
 
-    public CreateShippingResponse findByShippingId(Long shippingId) {
+    public DetailShippingResponse findByShippingId(Long shippingId) {
         ShippingAddress shippingAddress = shippingAddressRepository.findById(shippingId)
             .orElseThrow(
                 () -> new UserException(SHIPPING_ADDRESS_NOT_FOUND, String.valueOf(shippingId)));
-        return CreateShippingResponse.from(shippingAddress);
+        return DetailShippingResponse.from(shippingAddress);
     }
 
     public void deleteShippingAddress(Long shippingId) {

--- a/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
@@ -139,6 +139,7 @@ public class UserService {
         return DetailShippingResponse.from(shippingAddress);
     }
 
+    @Transactional(readOnly = true)
     public DetailShippingResponse findByShippingId(Long shippingId) {
         ShippingAddress shippingAddress = shippingAddressRepository.findById(shippingId)
             .orElseThrow(

--- a/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
@@ -19,6 +19,7 @@ import com.programmers.smrtstore.domain.user.presentation.dto.res.DetailShipping
 import com.programmers.smrtstore.domain.user.presentation.dto.res.ProfileUserResponse;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -81,9 +82,8 @@ public class UserService {
     private void checkShippingDuplicate(DetailShippingRequest request,
         List<ShippingAddress> shippingAddresses) {
         shippingAddresses.forEach(address -> {
-            if ((address.getPhoneNum2() == null && request.getPhoneNum2() == null)
-                || (address.getPhoneNum2() != null && request.getPhoneNum2() != null
-                && address.getPhoneNum2().equals(request.getPhoneNum2()))) {
+
+            if (Objects.equals(request.getPhoneNum2(), address.getPhoneNum2())) {
                 if (address.getName().equals(request.getName())
                     && address.getRecipient().equals(request.getRecipient())
                     && address.getAddress1Depth().equals(request.getAddress1Depth())

--- a/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
@@ -16,9 +16,10 @@ import com.programmers.smrtstore.domain.user.presentation.dto.req.UpdateUserRequ
 import com.programmers.smrtstore.domain.user.presentation.dto.res.CreateShippingResponse;
 import com.programmers.smrtstore.domain.user.presentation.dto.res.DeliveryAddressBook;
 import com.programmers.smrtstore.domain.user.presentation.dto.res.ProfileUserResponse;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -62,6 +63,7 @@ public class UserService {
         ShippingAddress shippingAddress = request.toShippingAddressEntity(user);
         checkShippingDuplicate(shippingAddress, shippingAddresses);
         user.addShippingAddress(shippingAddress);
+        shippingAddressRepository.save(shippingAddress);
 
         return CreateShippingResponse.from(shippingAddress);
     }
@@ -100,16 +102,18 @@ public class UserService {
 
     private AggUserShippingInfo separateDefaultShippingAddress(
         List<ShippingAddress> shippingAddresses) {
+        List<ShippingAddress> notDefaultShippingAddresses = new ArrayList<>();
         ShippingAddress defaultShippingAddress = null;
+
         for (ShippingAddress address : shippingAddresses) {
-            if (address.isDefaultYn()) {
+            if (!address.isDefaultYn()) {
+                notDefaultShippingAddresses.add(address);
+            } else {
                 defaultShippingAddress = address;
-                shippingAddresses.remove(address);
-                break;
             }
         }
 
-        return AggUserShippingInfo.of(defaultShippingAddress, shippingAddresses);
+        return AggUserShippingInfo.of(defaultShippingAddress, notDefaultShippingAddresses);
     }
 
     public CreateShippingResponse findByShippingId(Long shippingId) {

--- a/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
@@ -19,6 +19,7 @@ import com.programmers.smrtstore.domain.user.presentation.dto.res.DetailShipping
 import com.programmers.smrtstore.domain.user.presentation.dto.res.ProfileUserResponse;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -61,7 +62,7 @@ public class UserService {
 
         checkShippingAddressesSize(shippingAddresses);
         ShippingAddress shippingAddress = request.toShippingAddressEntity(user);
-        checkShippingDuplicate(shippingAddress, shippingAddresses);
+        checkShippingDuplicate(request, shippingAddresses);
         if (shippingAddress.isDefaultYn()) {
             user.disableOriginalDefault();
         }
@@ -78,20 +79,20 @@ public class UserService {
         }
     }
 
-    private void checkShippingDuplicate(ShippingAddress shippingAddress,
+    private void checkShippingDuplicate(DetailShippingRequest request,
         List<ShippingAddress> shippingAddresses) {
         shippingAddresses.forEach(address -> {
-            if ((address.getPhoneNum2() == null && shippingAddress.getPhoneNum2() == null)
-                || (address.getPhoneNum2() != null && shippingAddress.getPhoneNum2() != null
-                && address.getPhoneNum2().equals(shippingAddress.getPhoneNum2()))) {
-                if (address.getName().equals(shippingAddress.getName())
-                    && address.getRecipient().equals(shippingAddress.getRecipient())
-                    && address.getAddress1Depth().equals(shippingAddress.getAddress1Depth())
-                    && address.getAddress2Depth().equals(shippingAddress.getAddress2Depth())
-                    && address.getZipCode().equals(shippingAddress.getZipCode())
-                    && address.getPhoneNum1().equals(shippingAddress.getPhoneNum1())) {
+            if ((address.getPhoneNum2() == null && request.getPhoneNum2() == null)
+                || (address.getPhoneNum2() != null && request.getPhoneNum2() != null
+                && address.getPhoneNum2().equals(request.getPhoneNum2()))) {
+                if (address.getName().equals(request.getName())
+                    && address.getRecipient().equals(request.getRecipient())
+                    && address.getAddress1Depth().equals(request.getAddress1Depth())
+                    && address.getAddress2Depth().equals(request.getAddress2Depth())
+                    && address.getZipCode().equals(request.getZipCode())
+                    && address.getPhoneNum1().equals(request.getPhoneNum1())) {
                     throw new UserException(DUPLICATE_SHIPPING_ADDRESS,
-                        String.valueOf(shippingAddress.getId()));
+                        String.valueOf(address.getId()));
                 }
             }
         });
@@ -130,12 +131,12 @@ public class UserService {
             .orElseThrow(
                 () -> new UserException(SHIPPING_ADDRESS_NOT_FOUND, String.valueOf(shippingId)));
 
+        checkShippingDuplicate(request, user.getShippingAddresses());
         if (!shippingAddress.isDefaultYn() && request.isDefaultYn()) //기본 배송지 갱신할 경우
         {
             user.disableOriginalDefault();
         }
         shippingAddress.updateShippingAddress(request);
-
         return DetailShippingResponse.from(shippingAddress);
     }
 

--- a/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
@@ -126,11 +126,15 @@ public class UserService {
         return DetailShippingResponse.from(shippingAddress);
     }
 
-    public void deleteShippingAddress(Long shippingId) {
+    public void deleteShippingAddress(Long userId, Long shippingId) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new UserException(USER_NOT_FOUND, String.valueOf(userId)));
         ShippingAddress shippingAddress = shippingAddressRepository.findById(shippingId)
             .orElseThrow(
                 () -> new UserException(SHIPPING_ADDRESS_NOT_FOUND, String.valueOf(shippingId)));
         checkIsDefault(shippingId, shippingAddress);
+
+        user.deleteShippingAddress(shippingId);
         shippingAddressRepository.delete(shippingAddress);
     }
 

--- a/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
@@ -2,12 +2,14 @@ package com.programmers.smrtstore.domain.user.application;
 
 import static com.programmers.smrtstore.core.properties.ErrorCode.DUPLICATE_SHIPPING_ADDRESS;
 import static com.programmers.smrtstore.core.properties.ErrorCode.EXCEEDED_MAXIMUM_NUMBER_OF_SHIPPING_ADDRESS;
+import static com.programmers.smrtstore.core.properties.ErrorCode.SHIPPING_ADDRESS_NOT_FOUND;
 import static com.programmers.smrtstore.core.properties.ErrorCode.USER_NOT_FOUND;
 
 import com.programmers.smrtstore.domain.user.application.vo.AggUserShippingInfo;
 import com.programmers.smrtstore.domain.user.domain.entity.ShippingAddress;
 import com.programmers.smrtstore.domain.user.domain.entity.User;
 import com.programmers.smrtstore.domain.user.exception.UserException;
+import com.programmers.smrtstore.domain.user.infrastructure.ShippingAddressJpaRepository;
 import com.programmers.smrtstore.domain.user.infrastructure.UserRepository;
 import com.programmers.smrtstore.domain.user.presentation.dto.req.CreateShippingRequest;
 import com.programmers.smrtstore.domain.user.presentation.dto.req.UpdateUserRequest;
@@ -15,6 +17,7 @@ import com.programmers.smrtstore.domain.user.presentation.dto.res.CreateShipping
 import com.programmers.smrtstore.domain.user.presentation.dto.res.DeliveryAddressBook;
 import com.programmers.smrtstore.domain.user.presentation.dto.res.ProfileUserResponse;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,6 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final ShippingAddressJpaRepository shippingAddressRepository;
     private static final int MAXIMUM_SHIPPING_SIZE = 15;
 
 
@@ -106,5 +110,12 @@ public class UserService {
         }
 
         return AggUserShippingInfo.of(defaultShippingAddress, shippingAddresses);
+    }
+
+    public CreateShippingResponse findByShippingId(Long shippingId) {
+        ShippingAddress shippingAddress = shippingAddressRepository.findById(shippingId)
+            .orElseThrow(
+                () -> new UserException(SHIPPING_ADDRESS_NOT_FOUND, String.valueOf(shippingId)));
+        return CreateShippingResponse.from(shippingAddress);
     }
 }

--- a/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
@@ -78,15 +78,17 @@ public class UserService {
     private void checkShippingDuplicate(ShippingAddress shippingAddress,
         List<ShippingAddress> shippingAddresses) {
         shippingAddresses.forEach(address -> {
-            if (address.getName().equals(shippingAddress.getName())
-                && address.getRecipient().equals(shippingAddress.getRecipient())
-                && address.getAddress1Depth().equals(shippingAddress.getAddress1Depth())
-                && address.getAddress2Depth().equals(shippingAddress.getAddress2Depth())
-                && address.getZipCode().equals(shippingAddress.getZipCode())
-                && address.getPhoneNum1().equals(shippingAddress.getPhoneNum1())
-                && address.getPhoneNum2().equals(shippingAddress.getPhoneNum2())) {
-                throw new UserException(DUPLICATE_SHIPPING_ADDRESS,
-                    String.valueOf(shippingAddress.getId()));
+            if((address.getPhoneNum2() == null && shippingAddress.getPhoneNum2() == null)
+            || (address.getPhoneNum2() != null && shippingAddress.getPhoneNum2() != null && address.getPhoneNum2().equals(shippingAddress.getPhoneNum2()))) {
+                if (address.getName().equals(shippingAddress.getName())
+                    && address.getRecipient().equals(shippingAddress.getRecipient())
+                    && address.getAddress1Depth().equals(shippingAddress.getAddress1Depth())
+                    && address.getAddress2Depth().equals(shippingAddress.getAddress2Depth())
+                    && address.getZipCode().equals(shippingAddress.getZipCode())
+                    && address.getPhoneNum1().equals(shippingAddress.getPhoneNum1())) {
+                    throw new UserException(DUPLICATE_SHIPPING_ADDRESS,
+                        String.valueOf(shippingAddress.getId()));
+                }
             }
         });
     }

--- a/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/application/UserService.java
@@ -1,6 +1,6 @@
 package com.programmers.smrtstore.domain.user.application;
 
-import static com.programmers.smrtstore.core.properties.ErrorCode.DELETE_DEFAULT_SHIPPING;
+import static com.programmers.smrtstore.core.properties.ErrorCode.DEFAULT_SHIPPING_NOT_DELETABLE;
 import static com.programmers.smrtstore.core.properties.ErrorCode.DUPLICATE_SHIPPING_ADDRESS;
 import static com.programmers.smrtstore.core.properties.ErrorCode.EXCEEDED_MAXIMUM_NUMBER_OF_SHIPPING_ADDRESS;
 import static com.programmers.smrtstore.core.properties.ErrorCode.SHIPPING_ADDRESS_NOT_FOUND;
@@ -19,7 +19,6 @@ import com.programmers.smrtstore.domain.user.presentation.dto.res.DetailShipping
 import com.programmers.smrtstore.domain.user.presentation.dto.res.ProfileUserResponse;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -162,7 +161,7 @@ public class UserService {
 
     private void checkIsDefault(Long shippingId, ShippingAddress shippingAddress) {
         if (shippingAddress.isDefaultYn()) {
-            throw new UserException(DELETE_DEFAULT_SHIPPING, String.valueOf(shippingId));
+            throw new UserException(DEFAULT_SHIPPING_NOT_DELETABLE, String.valueOf(shippingId));
         }
     }
 }

--- a/src/main/java/com/programmers/smrtstore/domain/user/domain/entity/ShippingAddress.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/domain/entity/ShippingAddress.java
@@ -1,5 +1,6 @@
 package com.programmers.smrtstore.domain.user.domain.entity;
 
+import com.programmers.smrtstore.domain.user.presentation.dto.req.DetailShippingRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -56,5 +57,16 @@ public class ShippingAddress {
 
     public void disableDefault() {
         defaultYn = false;
+    }
+
+    public void updateShippingAddress(DetailShippingRequest request) {
+        this.name = request.getName();
+        this.recipient = request.getRecipient();
+        this.address1Depth = request.getAddress1Depth();
+        this.address2Depth = request.getAddress2Depth();
+        this.zipCode = request.getZipCode();
+        this.phoneNum1 = request.getPhoneNum1();
+        this.phoneNum2 = request.getPhoneNum2();
+        this.defaultYn = request.isDefaultYn();
     }
 }

--- a/src/main/java/com/programmers/smrtstore/domain/user/domain/entity/User.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/domain/entity/User.java
@@ -14,6 +14,7 @@ import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Stream;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -131,6 +132,15 @@ public class User {
         for (ShippingAddress shippingAddress : shippingAddresses) {
             if (shippingAddress.isDefaultYn()) {
                 shippingAddress.disableDefault();
+                break;
+            }
+        }
+    }
+
+    public void deleteShippingAddress(Long shippingId) {
+        for(ShippingAddress address : shippingAddresses) {
+            if(address.getId().equals(shippingId)) {
+                shippingAddresses.remove(address);
                 break;
             }
         }

--- a/src/main/java/com/programmers/smrtstore/domain/user/domain/entity/User.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/domain/entity/User.java
@@ -14,7 +14,6 @@ import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Stream;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -122,13 +121,10 @@ public class User {
     }
 
     public void addShippingAddress(ShippingAddress shippingAddress) {
-        if(shippingAddress.isDefaultYn()) {
-            disableOriginalDefault();
-        }
         shippingAddresses.add(shippingAddress);
     }
 
-    private void disableOriginalDefault() {
+    public void disableOriginalDefault() {
         for (ShippingAddress shippingAddress : shippingAddresses) {
             if (shippingAddress.isDefaultYn()) {
                 shippingAddress.disableDefault();
@@ -138,8 +134,8 @@ public class User {
     }
 
     public void deleteShippingAddress(Long shippingId) {
-        for(ShippingAddress address : shippingAddresses) {
-            if(address.getId().equals(shippingId)) {
+        for (ShippingAddress address : shippingAddresses) {
+            if (address.getId().equals(shippingId)) {
                 shippingAddresses.remove(address);
                 break;
             }

--- a/src/main/java/com/programmers/smrtstore/domain/user/domain/entity/User.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/domain/entity/User.java
@@ -121,13 +121,13 @@ public class User {
     }
 
     public void addShippingAddress(ShippingAddress shippingAddress) {
-        if (shippingAddress.isDefaultYn()) {
-            unlockOriginalDefault();
+        if(shippingAddress.isDefaultYn()) {
+            disableOriginalDefault();
         }
         shippingAddresses.add(shippingAddress);
     }
 
-    private void unlockOriginalDefault() {
+    private void disableOriginalDefault() {
         for (ShippingAddress shippingAddress : shippingAddresses) {
             if (shippingAddress.isDefaultYn()) {
                 shippingAddress.disableDefault();

--- a/src/main/java/com/programmers/smrtstore/domain/user/domain/entity/User.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/domain/entity/User.java
@@ -134,11 +134,6 @@ public class User {
     }
 
     public void deleteShippingAddress(Long shippingId) {
-        for (ShippingAddress address : shippingAddresses) {
-            if (address.getId().equals(shippingId)) {
-                shippingAddresses.remove(address);
-                break;
-            }
-        }
+        shippingAddresses.removeIf(address -> address.getId().equals(shippingId));
     }
 }

--- a/src/main/java/com/programmers/smrtstore/domain/user/exception/UserException.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/exception/UserException.java
@@ -5,6 +5,10 @@ import com.programmers.smrtstore.exception.exceptionClass.CustomException;
 
 public class UserException extends CustomException {
 
+    public UserException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
     public UserException(ErrorCode errorCode, String runtimeValue) {
         super(errorCode, runtimeValue);
     }

--- a/src/main/java/com/programmers/smrtstore/domain/user/infrastructure/ShippingAddressJpaRepository.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/infrastructure/ShippingAddressJpaRepository.java
@@ -1,0 +1,8 @@
+package com.programmers.smrtstore.domain.user.infrastructure;
+
+import com.programmers.smrtstore.domain.user.domain.entity.ShippingAddress;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ShippingAddressJpaRepository extends JpaRepository<ShippingAddress, Long> {
+
+}

--- a/src/main/java/com/programmers/smrtstore/domain/user/presentation/UserController.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/presentation/UserController.java
@@ -68,8 +68,8 @@ public class UserController {
     }
 
     @DeleteMapping("/shipping/{shippingId}")
-    public ResponseEntity<Void> deleteShippingAddress(@PathVariable Long shippingId) {
-        userService.deleteShippingAddress(shippingId);
+    public ResponseEntity<Void> deleteShippingAddress(@UserId Long userId, @PathVariable Long shippingId) {
+        userService.deleteShippingAddress(userId, shippingId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/programmers/smrtstore/domain/user/presentation/UserController.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/presentation/UserController.java
@@ -2,9 +2,9 @@ package com.programmers.smrtstore.domain.user.presentation;
 
 import com.programmers.smrtstore.common.annotation.UserId;
 import com.programmers.smrtstore.domain.user.application.UserService;
-import com.programmers.smrtstore.domain.user.presentation.dto.req.CreateShippingRequest;
+import com.programmers.smrtstore.domain.user.presentation.dto.req.DetailShippingRequest;
 import com.programmers.smrtstore.domain.user.presentation.dto.req.UpdateUserRequest;
-import com.programmers.smrtstore.domain.user.presentation.dto.res.CreateShippingResponse;
+import com.programmers.smrtstore.domain.user.presentation.dto.res.DetailShippingResponse;
 import com.programmers.smrtstore.domain.user.presentation.dto.res.DeliveryAddressBook;
 import com.programmers.smrtstore.domain.user.presentation.dto.res.ProfileUserResponse;
 import jakarta.validation.Valid;
@@ -47,10 +47,10 @@ public class UserController {
     }
 
     @PostMapping("/shipping")
-    public ResponseEntity<CreateShippingResponse> createShippingAddress(
+    public ResponseEntity<DetailShippingResponse> createShippingAddress(
         @UserId Long userId,
-        @RequestBody @Valid CreateShippingRequest request) {
-        CreateShippingResponse response = userService.createShippingAddress(userId, request);
+        @RequestBody @Valid DetailShippingRequest request) {
+        DetailShippingResponse response = userService.createShippingAddress(userId, request);
         return ResponseEntity.ok(response);
     }
 
@@ -62,8 +62,8 @@ public class UserController {
     }
 
     @GetMapping("/shipping/{shippingId}")
-    public ResponseEntity<CreateShippingResponse> findByShippingId(@PathVariable Long shippingId) {
-        CreateShippingResponse response = userService.findByShippingId(shippingId);
+    public ResponseEntity<DetailShippingResponse> findByShippingId(@PathVariable Long shippingId) {
+        DetailShippingResponse response = userService.findByShippingId(shippingId);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/programmers/smrtstore/domain/user/presentation/UserController.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/presentation/UserController.java
@@ -4,8 +4,8 @@ import com.programmers.smrtstore.common.annotation.UserId;
 import com.programmers.smrtstore.domain.user.application.UserService;
 import com.programmers.smrtstore.domain.user.presentation.dto.req.DetailShippingRequest;
 import com.programmers.smrtstore.domain.user.presentation.dto.req.UpdateUserRequest;
-import com.programmers.smrtstore.domain.user.presentation.dto.res.DetailShippingResponse;
 import com.programmers.smrtstore.domain.user.presentation.dto.res.DeliveryAddressBook;
+import com.programmers.smrtstore.domain.user.presentation.dto.res.DetailShippingResponse;
 import com.programmers.smrtstore.domain.user.presentation.dto.res.ProfileUserResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -61,6 +61,14 @@ public class UserController {
         return ResponseEntity.ok(response);
     }
 
+    @PostMapping("shipping/{shippingId}")
+    public ResponseEntity<DetailShippingResponse> updateDefaultShippingAddress(@UserId Long userId,
+        @PathVariable Long shippingId, @RequestBody @Valid DetailShippingRequest request) {
+        DetailShippingResponse response = userService.updateShippingAddress(userId, shippingId,
+            request);
+        return ResponseEntity.ok(response);
+    }
+
     @GetMapping("/shipping/{shippingId}")
     public ResponseEntity<DetailShippingResponse> findByShippingId(@PathVariable Long shippingId) {
         DetailShippingResponse response = userService.findByShippingId(shippingId);
@@ -68,7 +76,8 @@ public class UserController {
     }
 
     @DeleteMapping("/shipping/{shippingId}")
-    public ResponseEntity<Void> deleteShippingAddress(@UserId Long userId, @PathVariable Long shippingId) {
+    public ResponseEntity<Void> deleteShippingAddress(@UserId Long userId,
+        @PathVariable Long shippingId) {
         userService.deleteShippingAddress(userId, shippingId);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/programmers/smrtstore/domain/user/presentation/UserController.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/presentation/UserController.java
@@ -66,4 +66,10 @@ public class UserController {
         CreateShippingResponse response = userService.findByShippingId(shippingId);
         return ResponseEntity.ok(response);
     }
+
+    @DeleteMapping("/shipping/{shippingId}")
+    public ResponseEntity<Void> deleteShippingAddress(@PathVariable Long shippingId) {
+        userService.deleteShippingAddress(shippingId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/programmers/smrtstore/domain/user/presentation/UserController.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/presentation/UserController.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -57,6 +58,12 @@ public class UserController {
     public ResponseEntity<DeliveryAddressBook> shippingAddressList(
         @UserId Long userId) {
         DeliveryAddressBook response = userService.getShippingAddressList(userId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/shipping/{shippingId}")
+    public ResponseEntity<CreateShippingResponse> findByShippingId(@PathVariable Long shippingId) {
+        CreateShippingResponse response = userService.findByShippingId(shippingId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/programmers/smrtstore/domain/user/presentation/dto/req/DetailShippingRequest.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/presentation/dto/req/DetailShippingRequest.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class CreateShippingRequest {
+public class DetailShippingRequest {
 
     @Size(max = 10, message = "배송지 이름은 10자 이하여야 합니다.")
     private String name;

--- a/src/main/java/com/programmers/smrtstore/domain/user/presentation/dto/res/CreateShippingResponse.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/presentation/dto/res/CreateShippingResponse.java
@@ -8,6 +8,8 @@ import lombok.Getter;
 @Builder
 public class CreateShippingResponse {
 
+    private Long id;
+
     private String name;
 
     private String recipient;
@@ -26,6 +28,7 @@ public class CreateShippingResponse {
 
     public static CreateShippingResponse from(ShippingAddress address) {
         return CreateShippingResponse.builder()
+            .id(address.getId())
             .name(address.getName())
             .recipient(address.getRecipient())
             .address1Depth(address.getAddress1Depth())

--- a/src/main/java/com/programmers/smrtstore/domain/user/presentation/dto/res/DetailShippingResponse.java
+++ b/src/main/java/com/programmers/smrtstore/domain/user/presentation/dto/res/DetailShippingResponse.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class CreateShippingResponse {
+public class DetailShippingResponse {
 
     private Long id;
 
@@ -26,8 +26,8 @@ public class CreateShippingResponse {
 
     private boolean isDefaultYn;
 
-    public static CreateShippingResponse from(ShippingAddress address) {
-        return CreateShippingResponse.builder()
+    public static DetailShippingResponse from(ShippingAddress address) {
+        return DetailShippingResponse.builder()
             .id(address.getId())
             .name(address.getName())
             .recipient(address.getRecipient())

--- a/src/test/java/com/programmers/smrtstore/domain/user/application/UserServiceTest.java
+++ b/src/test/java/com/programmers/smrtstore/domain/user/application/UserServiceTest.java
@@ -38,6 +38,9 @@ class UserServiceTest {
     @Autowired
     AuthJpaRepository authJpaRepository;
 
+    @Autowired
+    ShippingAddressJpaRepository shippingAddressJpaRepository;
+
     SignUpRequest kazuha = SignUpRequest.builder()
         .username("kazuha")
         .password("1234")
@@ -92,6 +95,7 @@ class UserServiceTest {
     void createShippingAddress() {
         DetailShippingResponse response = userService.createShippingAddress(kazuhaId, request1);
 
+        assertThat(shippingAddressJpaRepository.findById(response.getId())).isNotNull();
         assertThat(response.getName()).isEqualTo(request1.getName());
         assertThat(response.getRecipient()).isEqualTo(request1.getRecipient());
         assertThat(response.getAddress1Depth()).isEqualTo(request1.getAddress1Depth());
@@ -100,6 +104,18 @@ class UserServiceTest {
         assertThat(response.getPhoneNum1()).isEqualTo(request1.getPhoneNum1());
         assertThat(response.getPhoneNum2()).isEqualTo(request1.getPhoneNum2());
         assertThat(response.isDefaultYn()).isEqualTo(request1.isDefaultYn());
+    }
+
+    @Test
+    @DisplayName("기본 배송지 등록 시 갱신")
+    void createDefaultShippingAddress() {
+        DetailShippingResponse response4 = userService.createShippingAddress(kazuhaId, request4);
+
+        DetailShippingResponse response5 = userService.createShippingAddress(kazuhaId,
+            request5);
+
+        assertThat(shippingAddressJpaRepository.findById(response4.getId()).get().isDefaultYn()).isFalse();
+        assertThat(shippingAddressJpaRepository.findById(response5.getId()).get().isDefaultYn()).isTrue();
     }
 
     @Test

--- a/src/test/java/com/programmers/smrtstore/domain/user/application/UserServiceTest.java
+++ b/src/test/java/com/programmers/smrtstore/domain/user/application/UserServiceTest.java
@@ -8,8 +8,8 @@ import com.programmers.smrtstore.domain.auth.infrastructure.AuthJpaRepository;
 import com.programmers.smrtstore.domain.user.domain.entity.Gender;
 import com.programmers.smrtstore.domain.user.domain.entity.Role;
 import com.programmers.smrtstore.domain.user.infrastructure.UserRepository;
-import com.programmers.smrtstore.domain.user.presentation.dto.req.CreateShippingRequest;
-import com.programmers.smrtstore.domain.user.presentation.dto.res.CreateShippingResponse;
+import com.programmers.smrtstore.domain.user.presentation.dto.req.DetailShippingRequest;
+import com.programmers.smrtstore.domain.user.presentation.dto.res.DetailShippingResponse;
 import com.programmers.smrtstore.domain.user.presentation.dto.res.DeliveryAddressBook;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -52,23 +52,23 @@ class UserServiceTest {
 
     Long kazuhaId;
 
-    CreateShippingRequest request1 = new CreateShippingRequest(
+    DetailShippingRequest request1 = new DetailShippingRequest(
         "집", "카즈하", "서울", "광진구", "12345",
         "01000000000", null, false
     );
-    CreateShippingRequest request2 = new CreateShippingRequest(
+    DetailShippingRequest request2 = new DetailShippingRequest(
         "학교", "카즈하", "서울", "광진구", "12345",
         "01000000000", "01012345678", false
     );
-    CreateShippingRequest request3 = new CreateShippingRequest(
+    DetailShippingRequest request3 = new DetailShippingRequest(
         "회사", "카즈하", "경기도", "분당시", "12345",
         "01000000000", "01012345678", false
     );
-    CreateShippingRequest request4 = new CreateShippingRequest(
+    DetailShippingRequest request4 = new DetailShippingRequest(
         "동방", "라이덴", "경기도", "분당시", "12345",
         "01000000000", "01012345678", true
     );
-    CreateShippingRequest request5 = new CreateShippingRequest(
+    DetailShippingRequest request5 = new DetailShippingRequest(
         "동방", "푸리나", "경기도", "분당시", "12345",
         "01000000000", "01012345678", true
     );
@@ -87,7 +87,7 @@ class UserServiceTest {
     @Test
     @DisplayName("배송지를 추가할 수 있다.")
     void createShippingAddress() {
-        CreateShippingResponse response = userService.createShippingAddress(kazuhaId, request1);
+        DetailShippingResponse response = userService.createShippingAddress(kazuhaId, request1);
 
         assertThat(response.getName()).isEqualTo(request1.getName());
         assertThat(response.getRecipient()).isEqualTo(request1.getRecipient());
@@ -117,9 +117,9 @@ class UserServiceTest {
     @Test
     @DisplayName("수정 시 배송지 정보를 배송지 id로 조회할 수 있다.")
     void findByShippingId() {
-        CreateShippingResponse response = userService.createShippingAddress(kazuhaId, request1);
+        DetailShippingResponse response = userService.createShippingAddress(kazuhaId, request1);
 
-        CreateShippingResponse byShippingId = userService.findByShippingId(response.getId());
+        DetailShippingResponse byShippingId = userService.findByShippingId(response.getId());
 
         assertThat(byShippingId.getName()).isEqualTo(request1.getName());
         assertThat(byShippingId.getRecipient()).isEqualTo(request1.getRecipient());

--- a/src/test/java/com/programmers/smrtstore/domain/user/application/UserServiceTest.java
+++ b/src/test/java/com/programmers/smrtstore/domain/user/application/UserServiceTest.java
@@ -52,6 +52,27 @@ class UserServiceTest {
 
     Long kazuhaId;
 
+    CreateShippingRequest request1 = new CreateShippingRequest(
+        "집", "카즈하", "서울", "광진구", "12345",
+        "01000000000", null, false
+    );
+    CreateShippingRequest request2 = new CreateShippingRequest(
+        "학교", "카즈하", "서울", "광진구", "12345",
+        "01000000000", "01012345678", false
+    );
+    CreateShippingRequest request3 = new CreateShippingRequest(
+        "회사", "카즈하", "경기도", "분당시", "12345",
+        "01000000000", "01012345678", false
+    );
+    CreateShippingRequest request4 = new CreateShippingRequest(
+        "동방", "라이덴", "경기도", "분당시", "12345",
+        "01000000000", "01012345678", true
+    );
+    CreateShippingRequest request5 = new CreateShippingRequest(
+        "동방", "푸리나", "경기도", "분당시", "12345",
+        "01000000000", "01012345678", true
+    );
+
     @BeforeEach
     public void beforeEach() {
         kazuhaId = authService.signUp(kazuha).getId();
@@ -66,45 +87,47 @@ class UserServiceTest {
     @Test
     @DisplayName("배송지를 추가할 수 있다.")
     void createShippingAddress() {
-        CreateShippingRequest request = new CreateShippingRequest(
-            "집", "카즈하", "서울", "광진구", "12345",
-            "01000000000", null, true
-        );
-        CreateShippingResponse response = userService.createShippingAddress(kazuhaId, request);
+        CreateShippingResponse response = userService.createShippingAddress(kazuhaId, request1);
 
-        assertThat(request.getName()).isEqualTo(response.getName());
-        assertThat(request.getRecipient()).isEqualTo(response.getRecipient());
-        assertThat(request.getAddress1Depth()).isEqualTo(response.getAddress1Depth());
-        assertThat(request.getAddress2Depth()).isEqualTo(response.getAddress2Depth());
-        assertThat(request.getZipCode()).isEqualTo(response.getZipCode());
-        assertThat(request.getPhoneNum1()).isEqualTo(response.getPhoneNum1());
-        assertThat(request.getPhoneNum2()).isEqualTo(response.getPhoneNum2());
-        assertThat(request.isDefaultYn()).isEqualTo(response.isDefaultYn());
+        assertThat(response.getName()).isEqualTo(request1.getName());
+        assertThat(response.getRecipient()).isEqualTo(request1.getRecipient());
+        assertThat(response.getAddress1Depth()).isEqualTo(request1.getAddress1Depth());
+        assertThat(response.getAddress2Depth()).isEqualTo(request1.getAddress2Depth());
+        assertThat(response.getZipCode()).isEqualTo(request1.getZipCode());
+        assertThat(response.getPhoneNum1()).isEqualTo(request1.getPhoneNum1());
+        assertThat(response.getPhoneNum2()).isEqualTo(request1.getPhoneNum2());
+        assertThat(response.isDefaultYn()).isEqualTo(request1.isDefaultYn());
     }
 
     @Test
     @DisplayName("user가 가지고 있는 배송지 목록을 조회할 수 있다.")
     void getShippingAddressList() {
-        CreateShippingRequest request1 = new CreateShippingRequest(
-            "집", "카즈하", "서울", "광진구", "12345",
-            "01000000000", null, true
-        );
-        CreateShippingRequest request2 = new CreateShippingRequest(
-            "학교", "카즈하", "서울", "광진구", "12345",
-            "01000000000", "01012345678", false
-        );
-        CreateShippingRequest request3 = new CreateShippingRequest(
-            "회사", "카즈하", "경기도", "분당시", "12345",
-            "01000000000", "01012345678", false
-        );
-
         userService.createShippingAddress(kazuhaId, request1);
         userService.createShippingAddress(kazuhaId, request2);
         userService.createShippingAddress(kazuhaId, request3);
+        userService.createShippingAddress(kazuhaId, request4);
+
         DeliveryAddressBook response = userService.getShippingAddressList(kazuhaId);
 
-        assertThat(response.getDefaultDeliveryAddress().getName()).isEqualTo("집");
-        assertThat(response.getDeliveryAddresses().size()).isEqualTo(2);
+        assertThat(userRepository.findById(1L).get().getShippingAddresses().size()).isEqualTo(4);
+        assertThat(response.getDefaultDeliveryAddress().getRecipient()).isEqualTo("라이덴");
+        assertThat(response.getDeliveryAddresses().size()).isEqualTo(3);
     }
 
+    @Test
+    @DisplayName("수정 시 배송지 정보를 배송지 id로 조회할 수 있다.")
+    void findByShippingId() {
+        CreateShippingResponse response = userService.createShippingAddress(kazuhaId, request1);
+
+        CreateShippingResponse byShippingId = userService.findByShippingId(response.getId());
+
+        assertThat(byShippingId.getName()).isEqualTo(request1.getName());
+        assertThat(byShippingId.getRecipient()).isEqualTo(request1.getRecipient());
+        assertThat(byShippingId.getAddress1Depth()).isEqualTo(request1.getAddress1Depth());
+        assertThat(byShippingId.getAddress2Depth()).isEqualTo(request1.getAddress2Depth());
+        assertThat(byShippingId.getZipCode()).isEqualTo(request1.getZipCode());
+        assertThat(byShippingId.getPhoneNum1()).isEqualTo(request1.getPhoneNum1());
+        assertThat(byShippingId.getPhoneNum2()).isEqualTo(request1.getPhoneNum2());
+        assertThat(byShippingId.isDefaultYn()).isEqualTo(request1.isDefaultYn());
+    }
 }

--- a/src/test/java/com/programmers/smrtstore/domain/user/application/UserServiceTest.java
+++ b/src/test/java/com/programmers/smrtstore/domain/user/application/UserServiceTest.java
@@ -128,7 +128,7 @@ class UserServiceTest {
 
         DeliveryAddressBook response = userService.getShippingAddressList(kazuhaId);
 
-        assertThat(userRepository.findById(1L).get().getShippingAddresses().size()).isEqualTo(4);
+        assertThat(userRepository.findById(kazuhaId).get().getShippingAddresses().size()).isEqualTo(4);
         assertThat(response.getDefaultDeliveryAddress().getRecipient()).isEqualTo("라이덴");
         assertThat(response.getDeliveryAddresses().size()).isEqualTo(3);
     }
@@ -174,5 +174,41 @@ class UserServiceTest {
 
         assertThatThrownBy(() -> userService.deleteShippingAddress(kazuhaId, response4.getId()))
             .isInstanceOf(UserException.class);
+    }
+
+    @Test
+    @DisplayName("기본 배송지를 수정할 수 있다.")
+    void updateDefaultShippingAddress() {
+        DetailShippingResponse response4 = userService.createShippingAddress(kazuhaId,
+            request4);
+
+        userService.updateShippingAddress(kazuhaId, response4.getId(), request5);
+
+        assertThat(shippingAddressJpaRepository.findById(response4.getId()).get().getRecipient()).isEqualTo("푸리나");
+        assertThat(shippingAddressJpaRepository.findById(response4.getId()).get().isDefaultYn()).isTrue();
+    }
+
+    @Test
+    @DisplayName("기본 배송지가 아닌 배송지를 기본 배송지로 수정할 수 있다.")
+    void updateNotDefaultToDefaultShippingAddress() {
+        DetailShippingResponse response1 = userService.createShippingAddress(kazuhaId,
+            request1);
+
+        userService.updateShippingAddress(kazuhaId, response1.getId(), request5);
+
+        assertThat(shippingAddressJpaRepository.findById(response1.getId()).get().getRecipient()).isEqualTo("푸리나");
+        assertThat(shippingAddressJpaRepository.findById(response1.getId()).get().isDefaultYn()).isTrue();
+    }
+
+    @Test
+    @DisplayName("기본 배송지가 아닌 배송지를 기본배송지가 아닌 배송지로 수정할 수 있다.")
+    void updateNotDefaultToNotDefaultShippingAddress() {
+        DetailShippingResponse response1 = userService.createShippingAddress(kazuhaId,
+            request1);
+
+        userService.updateShippingAddress(kazuhaId, response1.getId(), request2);
+
+        assertThat(shippingAddressJpaRepository.findById(response1.getId()).get().getRecipient()).isEqualTo("나히다");
+        assertThat(shippingAddressJpaRepository.findById(response1.getId()).get().isDefaultYn()).isFalse();
     }
 }


### PR DESCRIPTION
# 배송지 수정 시 기존 정보 불러오는 기능
- 기본 배송지의 경우 기본 배송지 여부 수정 불가 -> 클라이언트에서 처리

# 배송지 수정 기능
- 수정하려는 배송지가 기본 배송지가 아닌데 기본 배송지로 설정하고 싶은 경우, 기존의 기본 배송지를 해제해야 한다.
- 기본 배송지는 기본 배송지 여부를 선택할 수 없다.(클라이언트에서 기본 배송지일 경우 기본 배송지 선택 체크란을 주지 않음 -> 변경의 여지 없음)
- 기존 정보와 변함이 없으면 중복 오류
- 기본 배송지 수정 시 수정하려는 정보와 같은 정보가 이미 존재하면 덮어씀
- 기본 배송지 아닌 배송지 수정 시 수정하려는 정보와 같은 정보가 이미 존재하면 중복 오류

# 배송지 삭제 기능
- 기본 배송지는 삭제하지 못한다.