### PR TITLE
Refact/#183 Point Service 리팩토링 - 전반적인 리팩토링, 적립, 사용, 사용취소 로직 변경, 부분취소 도입

### DIFF
--- a/src/main/java/com/programmers/smrtstore/domain/point/application/PointDetailService.java
+++ b/src/main/java/com/programmers/smrtstore/domain/point/application/PointDetailService.java
@@ -204,19 +204,17 @@ public class PointDetailService {
         return cancelPoint;
     }
 
-    public Long saveExpirationHistory() {
+    public Integer saveExpirationHistory() {
 
         List<ExpiredPointDetailResponse> expireHistory = pointFacade.getExpiredSumGroupByOriginAcmId();
 
-        Long pointDetailId = null;
+        int expiredPoint = 0;
         for (ExpiredPointDetailResponse expireDetail : expireHistory) {
             PointDetail pointDetail = PointDetail.makeExpirationHistory(expireDetail);
             pointDetailRepository.save(pointDetail);
-            if (pointDetailId == null) {
-                pointDetailId = pointDetail.getId();
-            }
+            expiredPoint += pointDetail.getPointAmount();
         }
-        return pointDetailId;
+        return expiredPoint;
     }
 
     private User validateUserExists(Long userId) {

--- a/src/main/java/com/programmers/smrtstore/domain/point/application/PointFacade.java
+++ b/src/main/java/com/programmers/smrtstore/domain/point/application/PointFacade.java
@@ -10,11 +10,18 @@ import java.util.List;
 public interface PointFacade {
 
     PointResponse getPointById(Long pointId);
-    PointResponse getByOrderIdAndStatus(Long orderId, PointStatus pointStatus);
+    PointDetailResponse getAcmDetailByPointIdAndOriginAcmId(Long pointId);
+    PointResponse getUsedPointByOrderId(Long orderId);
+    List<PointResponse> findByPointIdAndPointStatus(Long pointId, PointStatus pointStatus);
+    List<PointResponse> getByOrderIdAndStatus(Long orderId, PointStatus pointStatus);
     List<PointDetailResponse> getUsedDetailByPointId(Long pointId);
     List<PointDetailResponse> getUsedDetailByOrderId(Long orderId);
+    List<PointDetailResponse> getUsedDetailByPointIdAndOrderedProductId(Long pointId, Long orderedProductId);
     boolean validateExpiredAt(PointResponse pointResponse);
     Integer makeNegativeNumber(Integer pointAmount);
     List<ExpiredPointDetailResponse> getExpiredSumGroupByOriginAcmId();
     List<PointDetailCustomResponse> getSumGroupByOriginAcmId(Long userId);
+    Integer getAcmPointByOrderId(Long orderId);
+    Integer getCancelPriceByPointIdAndOrderedProductId(Long pointId, Long orderedProductId);
+    Boolean getUserMembershipApplyYnByOrderId(Long orderId);
 }

--- a/src/main/java/com/programmers/smrtstore/domain/point/application/PointFacadeImpl.java
+++ b/src/main/java/com/programmers/smrtstore/domain/point/application/PointFacadeImpl.java
@@ -8,6 +8,7 @@ import com.programmers.smrtstore.domain.point.application.dto.res.ExpiredPointDe
 import com.programmers.smrtstore.domain.point.application.dto.res.PointDetailCustomResponse;
 import com.programmers.smrtstore.domain.point.application.dto.res.PointResponse;
 import com.programmers.smrtstore.domain.point.domain.entity.Point;
+import com.programmers.smrtstore.domain.point.domain.entity.PointDetail;
 import com.programmers.smrtstore.domain.point.domain.entity.enums.PointStatus;
 import com.programmers.smrtstore.domain.point.exception.PointException;
 import com.programmers.smrtstore.domain.point.infrastructure.PointDetailJpaRepository;
@@ -35,10 +36,33 @@ public class PointFacadeImpl implements PointFacade {
     }
 
     @Override
-    public PointResponse getByOrderIdAndStatus(Long orderId, PointStatus pointStatus) {
-        Point point = pointRepository.findByOrderIdAndPointStatus(orderId, pointStatus)
+    public PointDetailResponse getAcmDetailByPointIdAndOriginAcmId(Long pointId) {
+        PointDetail pointDetail = pointDetailRepository.findAcmDetailByPointIdAndOriginAcmId(pointId)
+            .orElseThrow(() -> new PointException(ErrorCode.POINT_NOT_FOUND));
+        return PointDetailResponse.from(pointDetail);
+    }
+
+    @Override
+    public PointResponse getUsedPointByOrderId(Long orderId) {
+        Point point = pointRepository.findUsedPointByOrderId(orderId)
             .orElseThrow(() -> new PointException(ErrorCode.POINT_NOT_FOUND));
         return PointResponse.from(point);
+    }
+
+    @Override
+    public List<PointResponse> findByPointIdAndPointStatus(Long pointId, PointStatus pointStatus) {
+        return pointRepository.findByPointIdAndPointStatus(pointId, pointStatus)
+            .stream()
+            .map(PointResponse::from)
+            .toList();
+    }
+
+    @Override
+    public List<PointResponse> getByOrderIdAndStatus(Long orderId, PointStatus pointStatus) {
+        return pointRepository.findByOrderIdAndPointStatus(orderId, pointStatus)
+            .stream()
+            .map(PointResponse::from)
+            .toList();
     }
 
     @Override
@@ -52,6 +76,17 @@ public class PointFacadeImpl implements PointFacade {
     @Override
     public List<PointDetailResponse> getUsedDetailByOrderId(Long orderId) {
         return pointDetailRepository.findUsedDetailsByOrderId(orderId)
+            .stream()
+            .map(PointDetailResponse::from)
+            .toList();
+    }
+
+    @Override
+    public List<PointDetailResponse> getUsedDetailByPointIdAndOrderedProductId(Long pointId, Long orderedProductId) {
+        return pointDetailRepository.getUsedDetailByPointIdAndOrderedProductId(
+                pointId,
+                orderedProductId
+            )
             .stream()
             .map(PointDetailResponse::from)
             .toList();
@@ -99,5 +134,23 @@ public class PointFacadeImpl implements PointFacade {
                     tuple.get(aliasIdxForSumOfPoint, Integer.class))
             )
             .toList();
+    }
+
+    @Override
+    public Integer getAcmPointByOrderId(Long orderId) {
+        return pointRepository.getAcmPointByOrderId(orderId);
+    }
+
+    @Override
+    public Integer getCancelPriceByPointIdAndOrderedProductId(Long pointId, Long orderedProductId) {
+        return pointDetailRepository.getPriceByPointIdAndOrderedProductId(
+            pointId,
+            orderedProductId
+        );
+    }
+
+    @Override
+    public Boolean getUserMembershipApplyYnByOrderId(Long orderId) {
+        return pointRepository.findUserMembershipApplyYnByOrderId(orderId);
     }
 }

--- a/src/main/java/com/programmers/smrtstore/domain/point/application/PointService.java
+++ b/src/main/java/com/programmers/smrtstore/domain/point/application/PointService.java
@@ -196,28 +196,14 @@ public class PointService {
         return pointAmount >= MAX_AVAILABLE_POINT;
     }
 
-    public PointResponse cancelAccumulatedPoint(PointRequest request) {
 
-        validateUserExists(request.getUserId());
-
-        Long orderId = request.getOrderId();
-        PointResponse pointResponse = pointFacade.getByOrderIdAndStatus(orderId, PointStatus.ACCUMULATED);
-
-        Point point = request.toEntity(
-            PointStatus.ACCUMULATE_CANCELED,
-            pointFacade.makeNegativeNumber(pointResponse.getPointValue()),
-            pointResponse.getMembershipApplyYn());
-        pointRepository.save(point);
-        return PointResponse.from(point);
-    }
-
-    public PointResponse usePoint(UsePointRequest request) {
+    public Long usePoint(UsePointRequest request) {
 
         User user = validateUserExists(request.getUserId());
 
         Point point = request.toEntity(user.getMembershipYn());
         pointRepository.save(point);
-        return PointResponse.from(point);
+        return point.getId();
     }
 
     public PointResponse cancelUsedPoint(PointRequest request) {

--- a/src/main/java/com/programmers/smrtstore/domain/point/application/PointService.java
+++ b/src/main/java/com/programmers/smrtstore/domain/point/application/PointService.java
@@ -206,19 +206,18 @@ public class PointService {
         return point.getId();
     }
 
-    public PointResponse cancelUsedPoint(PointRequest request) {
+    public Long cancelUsedPoint(PointRequest request) {
 
         validateUserExists(request.getUserId());
 
-        PointResponse pointResponse = pointFacade.getByOrderIdAndStatus(
-            request.getOrderId(),
-            PointStatus.USED
-        );
+        Long orderId = request.getOrderId();
+        PointResponse pointResponse = pointFacade.getUsedPointByOrderId(orderId);
 
         Point point = request.toEntity(
             PointStatus.USE_CANCELED,
             pointResponse.getPointValue(),
-            pointResponse.getMembershipApplyYn());
+            pointResponse.getMembershipApplyYn()
+        );
         pointRepository.save(point);
 
         int expiredPoint = calculateExpiredPoint(pointResponse.getOrderId());
@@ -229,7 +228,7 @@ public class PointService {
                 pointResponse.getMembershipApplyYn());
             pointRepository.save(expiredpoint);
         }
-        return PointResponse.from(point);
+        return point.getId();
     }
 
     private int calculateExpiredPoint(Long orderId) {

--- a/src/main/java/com/programmers/smrtstore/domain/point/application/PointService.java
+++ b/src/main/java/com/programmers/smrtstore/domain/point/application/PointService.java
@@ -57,9 +57,28 @@ public class PointService {
         for (OrderedProductResponse product : orderedProducts) {
             // 상품별 (1개당) 실제 적립되는 적립금 (기본 1% 적립 + 추가 4% 적립)
             int totalAcmPoint = calculateAcmPointPerProduct(product, userMonthlyTotalSpending);
+            Long id = saveAcmPointPerProduct(product, totalAcmPoint, user.getMembershipYn(), request);
             userMonthlyTotalSpending += product.getTotalPrice();
-            Point point = request.toEntity(PointStatus.ACCUMULATED, totalAcmPoint, user.getMembershipYn());
+            if (pointId == null) {
+                pointId = id;
+            }
+        }
+        return pointId;
+    }
+
+    private Long saveAcmPointPerProduct(OrderedProductResponse product,
+        int totalAcmPointPerProduct, boolean membershipYn, PointRequest request) {
+
+        Long pointId = null;
+        int count = product.getQuantity();
+        while (count != 0) {
+            Point point = request.toEntity(
+                PointStatus.ACCUMULATED,
+                totalAcmPointPerProduct / product.getQuantity(),
+                membershipYn
+            );
             pointRepository.save(point);
+            count -= 1;
             if (pointId == null) {
                 pointId = point.getId();
             }

--- a/src/main/java/com/programmers/smrtstore/domain/point/application/PointService.java
+++ b/src/main/java/com/programmers/smrtstore/domain/point/application/PointService.java
@@ -207,9 +207,8 @@ public class PointService {
     private int calculateAdditionalPointByRate(int available, int totalPrice, int rate, int nextRate) {
         if (available > totalPrice) {
             return totalPrice * rate / 100;
-        } else {
-            return available * rate / 100 + (totalPrice - available) * nextRate / 100;
         }
+        return available * rate / 100 + (totalPrice - available) * nextRate / 100;
     }
 
     private boolean isHigherThanMaxAvailablePoint(int pointAmount) {

--- a/src/main/java/com/programmers/smrtstore/domain/point/application/dto/req/AcmPointDetailRequest.java
+++ b/src/main/java/com/programmers/smrtstore/domain/point/application/dto/req/AcmPointDetailRequest.java
@@ -1,0 +1,30 @@
+package com.programmers.smrtstore.domain.point.application.dto.req;
+
+import com.programmers.smrtstore.domain.point.domain.entity.PointDetail;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class AcmPointDetailRequest {
+
+    private Long userId;
+    private Long orderId;
+    private List<Long> orderedProductIds;
+
+    public PointDetail toEntity(Long pointId, Long orderedProductId, Integer pointAmount, Long originAcmId) {
+        return PointDetail.builder()
+            .pointId(pointId)
+            .orderedProductId(orderedProductId)
+            .userId(userId)
+            .pointAmount(pointAmount)
+            .originAcmId(originAcmId)
+            .build();
+    }
+}

--- a/src/main/java/com/programmers/smrtstore/domain/point/application/dto/req/PointDetailRequest.java
+++ b/src/main/java/com/programmers/smrtstore/domain/point/application/dto/req/PointDetailRequest.java
@@ -16,9 +16,10 @@ public class PointDetailRequest {
     private Long userId;
     private Long pointId;
 
-    public PointDetail toEntity(Integer pointAmount, Long originAcmId) {
+    public PointDetail toEntity(Long orderedProductId, Integer pointAmount, Long originAcmId) {
         return PointDetail.builder()
             .pointId(pointId)
+            .orderedProductId(orderedProductId)
             .userId(userId)
             .pointAmount(pointAmount)
             .originAcmId(originAcmId)

--- a/src/main/java/com/programmers/smrtstore/domain/point/application/dto/req/UseCancelPointDetailRequest.java
+++ b/src/main/java/com/programmers/smrtstore/domain/point/application/dto/req/UseCancelPointDetailRequest.java
@@ -1,0 +1,31 @@
+package com.programmers.smrtstore.domain.point.application.dto.req;
+
+import com.programmers.smrtstore.domain.point.domain.entity.PointDetail;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class UseCancelPointDetailRequest {
+
+    private Long pointId;
+    private Long userId;
+    private List<Long> orderedProductIds; // 취소할 주문상품의 번호
+
+    public PointDetail toEntity(Long orderedProductId, Integer pointAmount, Long originAcmId) {
+        return PointDetail.builder()
+            .pointId(pointId)
+            .orderedProductId(orderedProductId)
+            .userId(userId)
+            .pointAmount(pointAmount)
+            .originAcmId(originAcmId)
+            .build();
+    }
+
+}

--- a/src/main/java/com/programmers/smrtstore/domain/point/domain/entity/Point.java
+++ b/src/main/java/com/programmers/smrtstore/domain/point/domain/entity/Point.java
@@ -21,7 +21,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "point_TB")
+@Table(name = "point_transaction_TB")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Point {

--- a/src/main/java/com/programmers/smrtstore/domain/point/domain/entity/PointDetail.java
+++ b/src/main/java/com/programmers/smrtstore/domain/point/domain/entity/PointDetail.java
@@ -13,7 +13,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "point_detail_TB")
+@Table(name = "point_detail_transaction_TB")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PointDetail {
@@ -26,6 +26,9 @@ public class PointDetail {
     @Column(name = "point_id")
     private Long pointId;
 
+    @Column(name = "ordered_product_id")
+    private Long orderedProductId;
+
     @Column(name = "user_id")
     private Long userId;
 
@@ -36,8 +39,9 @@ public class PointDetail {
     private Long originAcmId;
 
     @Builder
-    private PointDetail(Long pointId, Long userId, Integer pointAmount, Long originAcmId) {
+    private PointDetail(Long pointId, Long orderedProductId, Long userId, Integer pointAmount, Long originAcmId) {
         this.pointId = pointId;
+        this.orderedProductId = orderedProductId;
         this.userId = userId;
         this.pointAmount = pointAmount;
         this.originAcmId = originAcmId;
@@ -46,6 +50,7 @@ public class PointDetail {
     public static PointDetail makeExpirationHistory(ExpiredPointDetailResponse expireDetail) {
         return PointDetail.builder()
             .pointId(null)
+            .orderedProductId(null)
             .userId(expireDetail.getUserId())
             .pointAmount(expireDetail.getPointAmount() * -1)
             .originAcmId(expireDetail.getOriginAcmId())

--- a/src/main/java/com/programmers/smrtstore/domain/point/infrastructure/PointDetailJpaRepository.java
+++ b/src/main/java/com/programmers/smrtstore/domain/point/infrastructure/PointDetailJpaRepository.java
@@ -2,6 +2,7 @@ package com.programmers.smrtstore.domain.point.infrastructure;
 
 import com.programmers.smrtstore.domain.point.domain.entity.PointDetail;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -9,4 +10,7 @@ public interface PointDetailJpaRepository extends JpaRepository<PointDetail, Lon
 
     @Query("SELECT pd FROM PointDetail pd WHERE pd.pointId = :pointId")
     List<PointDetail> findUsedDetailByPointId(Long pointId);
+
+    @Query("SELECT pd FROM PointDetail pd WHERE pd.pointId = :pointId AND pd.originAcmId = :pointId")
+    Optional<PointDetail> findAcmDetailByPointIdAndOriginAcmId(Long pointId);
 }

--- a/src/main/java/com/programmers/smrtstore/domain/point/infrastructure/PointDetailRepositoryCustom.java
+++ b/src/main/java/com/programmers/smrtstore/domain/point/infrastructure/PointDetailRepositoryCustom.java
@@ -9,4 +9,6 @@ public interface PointDetailRepositoryCustom {
     List<PointDetail> findUsedDetailsByOrderId(Long orderId);
     List<Tuple> getSumGroupByOriginAcmId(Long userId);
     List<Tuple> getExpiredSumGroupByOriginAcmId();
+    List<PointDetail> getUsedDetailByPointIdAndOrderedProductId(Long pointId, Long orderedProductid);
+    Integer getPriceByPointIdAndOrderedProductId(Long pointId, Long orderedProductid);
 }

--- a/src/main/java/com/programmers/smrtstore/domain/point/infrastructure/PointDetailRepositoryCustomImpl.java
+++ b/src/main/java/com/programmers/smrtstore/domain/point/infrastructure/PointDetailRepositoryCustomImpl.java
@@ -87,4 +87,27 @@ public class PointDetailRepositoryCustomImpl implements PointDetailRepositoryCus
             .orderBy(pointDetail.originAcmId.asc())
             .fetch();
     }
+
+    @Override
+    public List<PointDetail> getUsedDetailByPointIdAndOrderedProductId(Long pointId, Long orderedProductid) {
+        return jpaQueryFactory
+            .selectFrom(pointDetail)
+            .where(
+                pointDetail.pointId.eq(pointId),
+                pointDetail.orderedProductId.eq(orderedProductid)
+            )
+            .fetch();
+    }
+
+    @Override
+    public Integer getPriceByPointIdAndOrderedProductId(Long pointId, Long orderedProductid) {
+        return jpaQueryFactory
+            .select(pointDetail.pointAmount.sum())
+            .from(pointDetail)
+            .where(
+                pointDetail.pointId.eq(pointId),
+                pointDetail.orderedProductId.eq(orderedProductid)
+            )
+            .fetchOne();
+    }
 }

--- a/src/main/java/com/programmers/smrtstore/domain/point/infrastructure/PointRepositoryCustom.java
+++ b/src/main/java/com/programmers/smrtstore/domain/point/infrastructure/PointRepositoryCustom.java
@@ -2,10 +2,14 @@ package com.programmers.smrtstore.domain.point.infrastructure;
 
 import com.programmers.smrtstore.domain.point.domain.entity.Point;
 import com.programmers.smrtstore.domain.point.domain.entity.enums.PointStatus;
+import java.util.List;
 import java.util.Optional;
 
 public interface PointRepositoryCustom {
 
-    Optional<Point> findByPointIdAndPointStatus(Long pointId, PointStatus pointStatus);
-    Optional<Point> findByOrderIdAndPointStatus(Long orderId, PointStatus pointStatus);
+    List<Point> findByPointIdAndPointStatus(Long pointId, PointStatus pointStatus);
+    Optional<Point> findUsedPointByOrderId(Long orderId);
+    List<Point> findByOrderIdAndPointStatus(Long orderId, PointStatus pointStatus);
+    Integer getAcmPointByOrderId(Long orderId);
+    Boolean findUserMembershipApplyYnByOrderId(Long orderId);
 }


### PR DESCRIPTION
## 🚀 개발 사항
- 전반적인 리팩토링
- 상품에 대한 최대 적립금 계산 메서드 파라미터 수정 및 userId 없는 메서드 추가
- `point_detail_transaction_TB` 테이블에 컬럼 추가 - `orderedProductId`
- 적립 이력 저장 방식을 `주문별` 에서 `상품별` (1개당) 으로 변경
- 적립 취소 기능 삭제
- 포인트 차감 시, 주문상품의 결제금액 비율별로 포인트 차감
- 주문 취소 시, 취소하는 주문상품의 결제금액 비율별 차감 포인트를 환불

### 이슈 번호
- close #183 

## 특이 사항 🫶 
리팩토링이라고 적혀있지만 테이블 구조나 이력에 대해 저장하는 방식이 많이 바뀌어서 거의 갈아엎은 수준입니다,,
최대한 주석을 적어놓기는 했는데 이해가 안되는 부분이 있다면 물어봐주십셔!🙇🏻‍♀️
현재 구현되어 있는 메서드 중 사용되지 않고 있는 메서드들이 있는데 추후에 리팩토링이 될 가능성이 있을 것 같아 삭제하지 않았습니다!
리팩토링이 완전하게 끝난 것은 아니고 중간중간 최적화나 리팩토링은 이어서 할 생각입니다.
설계 방식이나 구현 방식 중에, 더 좋은 아이디어가 있다면 피드백으로 공유해주시면 좋을 것 같습니다!👍🏻