### PR TITLE
Feat/#98 미작성 리뷰들에 대한 최대 예상 적립금 계산, 리뷰 포인트 적립 기능 구현

### DIFF
--- a/src/main/java/com/programmers/smrtstore/domain/point/application/PointDetailService.java
+++ b/src/main/java/com/programmers/smrtstore/domain/point/application/PointDetailService.java
@@ -5,6 +5,7 @@ import com.programmers.smrtstore.core.properties.ErrorCode;
 import com.programmers.smrtstore.domain.orderManagement.order.application.OrderService;
 import com.programmers.smrtstore.domain.orderManagement.order.presentation.dto.res.OrderedProductResponse;
 import com.programmers.smrtstore.domain.point.application.dto.req.AcmPointDetailRequest;
+import com.programmers.smrtstore.domain.point.application.dto.req.ReviewPointDetailRequest;
 import com.programmers.smrtstore.domain.point.application.dto.req.UseCancelPointDetailRequest;
 import com.programmers.smrtstore.domain.point.application.dto.res.ExpiredPointDetailResponse;
 import com.programmers.smrtstore.domain.point.application.dto.req.PointDetailRequest;
@@ -80,6 +81,16 @@ public class PointDetailService {
             pointDetailRepository.save(pointDetail);
         }
         return totalAcmPoint;
+    }
+
+    public Integer saveReviewAcmHistory(ReviewPointDetailRequest request) {
+
+        Long userId = request.getUserId();
+        validateUserExists(userId);
+
+        PointDetail pointDetail = request.toEntity();
+        pointDetailRepository.save(pointDetail);
+        return pointDetail.getPointAmount();
     }
 
     public Integer saveUseHistory(PointDetailRequest request) {

--- a/src/main/java/com/programmers/smrtstore/domain/point/application/PointService.java
+++ b/src/main/java/com/programmers/smrtstore/domain/point/application/PointService.java
@@ -4,6 +4,7 @@ import com.programmers.smrtstore.core.properties.ErrorCode;
 import com.programmers.smrtstore.domain.point.application.dto.req.PointHistoryRequest;
 import com.programmers.smrtstore.domain.orderManagement.order.application.OrderService;
 import com.programmers.smrtstore.domain.orderManagement.order.presentation.dto.res.OrderedProductResponse;
+import com.programmers.smrtstore.domain.point.application.dto.req.ReviewPointRequest;
 import com.programmers.smrtstore.domain.point.application.dto.res.OrderExpectedPointDto;
 import com.programmers.smrtstore.domain.point.application.dto.res.PointResponse;
 import com.programmers.smrtstore.domain.point.application.dto.res.ProductEstimatedPointDto;
@@ -17,6 +18,7 @@ import com.programmers.smrtstore.domain.point.application.dto.res.PointDetailRes
 import com.programmers.smrtstore.domain.product.domain.entity.Product;
 import com.programmers.smrtstore.domain.product.exception.ProductException;
 import com.programmers.smrtstore.domain.product.infrastructure.ProductJpaRepository;
+import com.programmers.smrtstore.domain.review.infrastructure.ReviewJpaRepository;
 import com.programmers.smrtstore.domain.user.domain.entity.User;
 import com.programmers.smrtstore.domain.user.exception.UserException;
 import com.programmers.smrtstore.domain.user.infrastructure.UserJpaRepository;
@@ -33,11 +35,13 @@ public class PointService {
 
     private final PointFacade pointFacade;
     private final OrderService orderService;
+    private final ReviewJpaRepository reviewRepository;
     private final ProductJpaRepository productRepository;
     private final UserJpaRepository userJpaRepository;
     private final PointJpaRepository pointRepository;
 
     public static final int MAX_AVAILALBE_USE_POINT = 2000000;
+    public static final int REVIEW_POINT = 50;
     private static final int MAX_AVAILABLE_POINT = 20000;
     private static final int MAX_PRICE_FOR_FOUR = 200000; // 4% 추가 적립이 가능한 월별 쇼핑 금액 기준
     private static final int MAX_PRICE_FOR_ONE = 3000000; // 1% 추가 적립이 가능한 월별 쇼핑 금액 기준
@@ -122,6 +126,23 @@ public class PointService {
             additionalPoint,
             defaultPoint + additionalPoint // 멤버십 적용된 최종 적립 (=구매적립)
         );
+    }
+
+    public Integer calculateMaximumPointForUnwrittenReview(Long userId) {
+
+        validateUserExists(userId);
+        Long unWritteReviewCount = reviewRepository.getUnWrittenReviewCount(userId);
+        return unWritteReviewCount == 0 ? 0 : unWritteReviewCount.intValue() * REVIEW_POINT;
+    }
+
+    public Long accumulatePointByReview(ReviewPointRequest request) {
+
+        Long userId = request.getUserId();
+        User user = validateUserExists(userId);
+
+        Point point = request.toEntity(user.getMembershipYn());
+        pointRepository.save(point);
+        return point.getId();
     }
 
     private int calculateDefaultPoint(Long orderId) {

--- a/src/main/java/com/programmers/smrtstore/domain/point/application/PointService.java
+++ b/src/main/java/com/programmers/smrtstore/domain/point/application/PointService.java
@@ -132,6 +132,10 @@ public class PointService {
 
         validateUserExists(userId);
         Long unWritteReviewCount = reviewRepository.getUnWrittenReviewCount(userId);
+        return calculateTotalReviewPoint(unWritteReviewCount);
+    }
+
+    private Integer calculateTotalReviewPoint(Long unWritteReviewCount) {
         return unWritteReviewCount == 0 ? 0 : unWritteReviewCount.intValue() * REVIEW_POINT;
     }
 

--- a/src/main/java/com/programmers/smrtstore/domain/point/application/dto/req/PointRequest.java
+++ b/src/main/java/com/programmers/smrtstore/domain/point/application/dto/req/PointRequest.java
@@ -1,6 +1,7 @@
 package com.programmers.smrtstore.domain.point.application.dto.req;
 
 import com.programmers.smrtstore.domain.point.domain.entity.Point;
+import com.programmers.smrtstore.domain.point.domain.entity.enums.PointLabel;
 import com.programmers.smrtstore.domain.point.domain.entity.enums.PointStatus;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -22,6 +23,7 @@ public class PointRequest {
             .userId(userId)
             .orderId(orderId)
             .pointStatus(pointStatus)
+            .pointLabel(PointLabel.ORDER)
             .pointValue(pointValue)
             .membershipApplyYn(membershipApplyYn)
             .build();

--- a/src/main/java/com/programmers/smrtstore/domain/point/application/dto/req/ReviewPointDetailRequest.java
+++ b/src/main/java/com/programmers/smrtstore/domain/point/application/dto/req/ReviewPointDetailRequest.java
@@ -1,0 +1,30 @@
+package com.programmers.smrtstore.domain.point.application.dto.req;
+
+import com.programmers.smrtstore.domain.point.application.PointService;
+import com.programmers.smrtstore.domain.point.domain.entity.PointDetail;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ReviewPointDetailRequest {
+
+    private Long pointId;
+    private Long userId;
+    private Long orderedProductId;
+
+    public PointDetail toEntity() {
+        return PointDetail.builder()
+            .pointId(pointId)
+            .userId(userId)
+            .orderedProductId(orderedProductId)
+            .pointAmount(PointService.REVIEW_POINT)
+            .originAcmId(pointId)
+            .build();
+    }
+}

--- a/src/main/java/com/programmers/smrtstore/domain/point/application/dto/req/ReviewPointRequest.java
+++ b/src/main/java/com/programmers/smrtstore/domain/point/application/dto/req/ReviewPointRequest.java
@@ -2,6 +2,7 @@ package com.programmers.smrtstore.domain.point.application.dto.req;
 
 import com.programmers.smrtstore.domain.point.application.PointService;
 import com.programmers.smrtstore.domain.point.domain.entity.Point;
+import com.programmers.smrtstore.domain.point.domain.entity.enums.PointLabel;
 import com.programmers.smrtstore.domain.point.domain.entity.enums.PointStatus;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -22,7 +23,8 @@ public class ReviewPointRequest {
         return Point.builder()
             .userId(userId)
             .orderId(orderId)
-            .pointStatus(PointStatus.REVIEW_ACCMULATED)
+            .pointStatus(PointStatus.ACCUMULATED)
+            .pointLabel(PointLabel.REVIEW)
             .pointValue(PointService.REVIEW_POINT)
             .membershipApplyYn(membershipApplyYn)
             .build();

--- a/src/main/java/com/programmers/smrtstore/domain/point/application/dto/req/ReviewPointRequest.java
+++ b/src/main/java/com/programmers/smrtstore/domain/point/application/dto/req/ReviewPointRequest.java
@@ -1,0 +1,31 @@
+package com.programmers.smrtstore.domain.point.application.dto.req;
+
+import com.programmers.smrtstore.domain.point.application.PointService;
+import com.programmers.smrtstore.domain.point.domain.entity.Point;
+import com.programmers.smrtstore.domain.point.domain.entity.enums.PointStatus;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ReviewPointRequest {
+
+    private Long userId;
+    private Long orderId;
+
+    public Point toEntity(boolean membershipApplyYn) {
+        return Point.builder()
+            .userId(userId)
+            .orderId(orderId)
+            .pointStatus(PointStatus.REVIEW_ACCMULATED)
+            .pointValue(PointService.REVIEW_POINT)
+            .membershipApplyYn(membershipApplyYn)
+            .build();
+    }
+
+}

--- a/src/main/java/com/programmers/smrtstore/domain/point/application/dto/req/UsePointRequest.java
+++ b/src/main/java/com/programmers/smrtstore/domain/point/application/dto/req/UsePointRequest.java
@@ -1,6 +1,7 @@
 package com.programmers.smrtstore.domain.point.application.dto.req;
 
 import com.programmers.smrtstore.domain.point.domain.entity.Point;
+import com.programmers.smrtstore.domain.point.domain.entity.enums.PointLabel;
 import com.programmers.smrtstore.domain.point.domain.entity.enums.PointStatus;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -23,6 +24,7 @@ public class UsePointRequest {
             .userId(userId)
             .orderId(orderId)
             .pointStatus(PointStatus.USED)
+            .pointLabel(PointLabel.ORDER)
             .pointValue(-1 * pointAmount)
             .membershipApplyYn(membershipApplyYn)
             .build();

--- a/src/main/java/com/programmers/smrtstore/domain/point/application/dto/res/PointResponse.java
+++ b/src/main/java/com/programmers/smrtstore/domain/point/application/dto/res/PointResponse.java
@@ -1,6 +1,7 @@
 package com.programmers.smrtstore.domain.point.application.dto.res;
 
 import com.programmers.smrtstore.domain.point.domain.entity.Point;
+import com.programmers.smrtstore.domain.point.domain.entity.enums.PointLabel;
 import com.programmers.smrtstore.domain.point.domain.entity.enums.PointStatus;
 import java.time.LocalDateTime;
 import lombok.Builder;
@@ -13,6 +14,7 @@ public class PointResponse {
     private Long userId;
     private Long orderId;
     private PointStatus status;
+    private PointLabel label;
     private Integer pointValue;
     private LocalDateTime issuedAt;
     private LocalDateTime expiredAt;
@@ -24,6 +26,7 @@ public class PointResponse {
         this.userId = point.getUserId();
         this.orderId = point.getOrderId();
         this.status = point.getPointStatus();
+        this.label = point.getPointLabel();
         this.pointValue = point.getPointValue();
         this.issuedAt = point.getIssuedAt();
         this.expiredAt = point.getExpiredAt();

--- a/src/main/java/com/programmers/smrtstore/domain/point/domain/entity/Point.java
+++ b/src/main/java/com/programmers/smrtstore/domain/point/domain/entity/Point.java
@@ -2,6 +2,7 @@ package com.programmers.smrtstore.domain.point.domain.entity;
 
 import com.programmers.smrtstore.core.properties.ErrorCode;
 import com.programmers.smrtstore.domain.point.application.PointService;
+import com.programmers.smrtstore.domain.point.domain.entity.enums.PointLabel;
 import com.programmers.smrtstore.domain.point.domain.entity.enums.PointStatus;
 import com.programmers.smrtstore.domain.point.exception.PointException;
 import jakarta.persistence.Column;
@@ -41,6 +42,10 @@ public class Point {
     @Column(name = "point_status", nullable = false)
     private PointStatus pointStatus;
 
+    @Enumerated(value = EnumType.STRING)
+    @Column(name = "point_label", nullable = false)
+    private PointLabel pointLabel;
+
     @Column(name = "point_value", nullable = false)
     private Integer pointValue;
 
@@ -56,11 +61,13 @@ public class Point {
     private Boolean membershipApplyYn;
 
     @Builder
-    private Point(Long userId, Long orderId, PointStatus pointStatus, Integer pointValue, Boolean membershipApplyYn) {
+    private Point(Long userId, Long orderId, PointStatus pointStatus, PointLabel pointLabel,
+            Integer pointValue, Boolean membershipApplyYn) {
         validatePointValue(pointStatus, pointValue);
         this.userId = userId;
         this.orderId = orderId;
         this.pointStatus = pointStatus;
+        this.pointLabel = pointLabel;
         this.pointValue = pointValue;
         this.issuedAt = LocalDateTime.now();
         this.expiredAt = setExpiredAt(pointStatus);

--- a/src/main/java/com/programmers/smrtstore/domain/point/domain/entity/enums/PointLabel.java
+++ b/src/main/java/com/programmers/smrtstore/domain/point/domain/entity/enums/PointLabel.java
@@ -1,0 +1,8 @@
+package com.programmers.smrtstore.domain.point.domain.entity.enums;
+
+public enum PointLabel {
+
+    ORDER,
+    REVIEW,
+    EVENT
+}

--- a/src/main/java/com/programmers/smrtstore/domain/point/domain/entity/enums/PointStatus.java
+++ b/src/main/java/com/programmers/smrtstore/domain/point/domain/entity/enums/PointStatus.java
@@ -3,6 +3,7 @@ package com.programmers.smrtstore.domain.point.domain.entity.enums;
 public enum PointStatus {
 
     ACCUMULATED,
+    REVIEW_ACCMULATED,
     USED,
     ACCUMULATE_CANCELED,
     USE_CANCELED,

--- a/src/main/java/com/programmers/smrtstore/domain/point/domain/entity/enums/PointStatus.java
+++ b/src/main/java/com/programmers/smrtstore/domain/point/domain/entity/enums/PointStatus.java
@@ -3,7 +3,6 @@ package com.programmers.smrtstore.domain.point.domain.entity.enums;
 public enum PointStatus {
 
     ACCUMULATED,
-    REVIEW_ACCMULATED,
     USED,
     ACCUMULATE_CANCELED,
     USE_CANCELED,


### PR DESCRIPTION
## 🚀 개발 사항
- [x] 미작성 리뷰의 개수를 받아와서 최대 예상 적립금 계산 기능 구현
`calculateMaximumPointForUnwrittenReview`

- [x] 리뷰 포인트 이력 저장 기능 구현
`accumulatePointByReview`

- [x] 리뷰 포인트 상세 이력 저장 기능 구현
`saveReviewAcmHistory`

### 이슈 번호
- close #98 

## 특이 사항 🫶 
- 구매를 통한 주문 적립과 구분을 두기 위해, `PointStatus` 에 `REVIEW_ACCUMULATED` 상태를 추가했습니다. 별도로 적립의 종류에 대한 컬럼을 추가할 수도 있지만, 다음과 같은 두 가지 이유로 인해 굳이 별도로 컬럼을 추가하지 않아도 될 것 같다고 판단했습니다! 이에 대해 더 좋은 아이디어나 의견을 가지신 분은 피드백으로 공유해주시면 좋을 것 같습니다!🙇🏻‍♀️

1. 리뷰가 작성되고 나서 7일간 삭제를 할 수 없기 때문에 적립된 리뷰 포인트가 취소될 일이 없는 점
2. 포인트를 사용하는 데에 있어서는 `originAcmId` 를 이용하기 때문에 문제가 되지 않는 점
3. 리뷰 포인트에 대해 조회해야 하는 경우가 포인트 이력 조회뿐이기 때문에 조건을 하나만 더 추가하면 되는 점

P.S. 3번의 경우 포인트 이력을 조회하는 로직이 상당히 번거로워지는 점 때문에 `PointStatus` 에 적립 상태를 추가하는 것이 아닌, **`PointLabel` 컬럼을 별도로 두도록** 했습니다!
