### PR TITLE
[FEAT] User 의 주문 내역, User의 활성화된 주문 count 서비스 구현

### DIFF
--- a/src/main/java/com/programmers/smrtstore/domain/orderManagement/order/application/OrderService.java
+++ b/src/main/java/com/programmers/smrtstore/domain/orderManagement/order/application/OrderService.java
@@ -3,6 +3,7 @@ package com.programmers.smrtstore.domain.orderManagement.order.application;
 import com.programmers.smrtstore.domain.orderManagement.order.presentation.dto.res.CreateOrderResponse;
 import com.programmers.smrtstore.domain.orderManagement.order.presentation.dto.req.CreateOrderRequest;
 import com.programmers.smrtstore.domain.orderManagement.order.presentation.dto.req.UpdateOrderRequest;
+import com.programmers.smrtstore.domain.orderManagement.order.presentation.dto.res.OrderPreviewResponse;
 import com.programmers.smrtstore.domain.orderManagement.order.presentation.dto.res.OrderResponse;
 import com.programmers.smrtstore.domain.orderManagement.order.presentation.dto.res.OrderedProductResponse;
 import java.util.List;
@@ -22,5 +23,9 @@ public interface OrderService {
     Integer getTotalPriceByOrderId(String orderId);
 
     List<OrderedProductResponse> getProductsForOrder(String orderId);
+
+    List<OrderPreviewResponse> getOrderPreviewsByUserId(Long userId);
+
+    Long getActiveOrderCountByUserId(Long userId);
 
 }

--- a/src/main/java/com/programmers/smrtstore/domain/orderManagement/order/application/OrderServiceImpl.java
+++ b/src/main/java/com/programmers/smrtstore/domain/orderManagement/order/application/OrderServiceImpl.java
@@ -4,11 +4,13 @@ import static com.programmers.smrtstore.core.properties.ErrorCode.ORDER_NOT_FOUN
 import static com.programmers.smrtstore.core.properties.ErrorCode.USER_NOT_FOUND;
 
 import com.programmers.smrtstore.domain.orderManagement.order.domain.entity.Order;
+import com.programmers.smrtstore.domain.orderManagement.order.domain.entity.enums.OrderStatus;
 import com.programmers.smrtstore.domain.orderManagement.order.exception.OrderException;
 import com.programmers.smrtstore.domain.orderManagement.order.infrastructure.OrderJpaRepository;
 import com.programmers.smrtstore.domain.orderManagement.order.presentation.dto.req.CreateOrderRequest;
 import com.programmers.smrtstore.domain.orderManagement.order.presentation.dto.req.UpdateOrderRequest;
 import com.programmers.smrtstore.domain.orderManagement.order.presentation.dto.res.CreateOrderResponse;
+import com.programmers.smrtstore.domain.orderManagement.order.presentation.dto.res.OrderPreviewResponse;
 import com.programmers.smrtstore.domain.orderManagement.order.presentation.dto.res.OrderResponse;
 import com.programmers.smrtstore.domain.orderManagement.order.presentation.dto.res.OrderedProductResponse;
 import com.programmers.smrtstore.domain.user.domain.entity.User;
@@ -75,6 +77,22 @@ public class OrderServiceImpl implements OrderService {
             .getOrderSheet().getOrderedProducts().stream()
             .map(OrderedProductResponse::from)
             .toList();
+    }
+
+    @Override
+    public List<OrderPreviewResponse> getOrderPreviewsByUserId(Long userId) {
+        checkUserExistence(userId);
+        List<Order> orders = orderJpaRepository.findByUserId(userId);
+
+        return orders.stream()
+            .map(OrderPreviewResponse::from)
+            .toList();
+    }
+
+    @Override
+    public Long getActiveOrderCountByUserId(Long userId) {
+        checkUserExistence(userId);
+        return orderJpaRepository.findOrderCountByStatusesAndUserId(userId, OrderStatus.getActiveOrderStatus());
     }
 
     private User checkUserExistence(Long userId) {

--- a/src/main/java/com/programmers/smrtstore/domain/orderManagement/order/domain/entity/enums/OrderStatus.java
+++ b/src/main/java/com/programmers/smrtstore/domain/orderManagement/order/domain/entity/enums/OrderStatus.java
@@ -1,5 +1,7 @@
 package com.programmers.smrtstore.domain.orderManagement.order.domain.entity.enums;
 
+import java.util.List;
+
 public enum OrderStatus {
     PAYMENT_WAITING, // 결제 대기
     PAYMENT_COMPLETED, // 결제 완료
@@ -12,5 +14,18 @@ public enum OrderStatus {
     REFUND_REQUESTED, // 환불 요청
     REFUND_COMPLETED, // 환불 완료
     CANCELLED_BY_NO_PAYMENT, // 미결제 주문 취소
-    DISPATCH_DELAYED, // 배송 지연
+    DISPATCH_DELAYED // 배송 지연
+    ;
+
+    public static List<OrderStatus> getActiveOrderStatus() {
+        return List.of(
+            PAYMENT_WAITING,
+            PAYMENT_COMPLETED,
+            DELIVERY_PREPARING,
+            DELIVERING_BEFORE,
+            DELIVERING,
+            DELIVERED,
+            DISPATCH_DELAYED
+        );
+    }
 }

--- a/src/main/java/com/programmers/smrtstore/domain/orderManagement/order/infrastructure/OrderJpaRepository.java
+++ b/src/main/java/com/programmers/smrtstore/domain/orderManagement/order/infrastructure/OrderJpaRepository.java
@@ -1,12 +1,21 @@
 package com.programmers.smrtstore.domain.orderManagement.order.infrastructure;
 
 import com.programmers.smrtstore.domain.orderManagement.order.domain.entity.Order;
+import com.programmers.smrtstore.domain.orderManagement.order.domain.entity.enums.OrderStatus;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface OrderJpaRepository extends JpaRepository<Order, Long>, OrderRepositoryCustom {
+
+    @Query("SELECT count(o) FROM Order o JOIN OrderSheet os ON o.orderSheet.id = os.id WHERE os.user.id = :userId AND o.orderStatus IN :statuses AND o.deletedAt IS NULL")
+    Long findOrderCountByStatusesAndUserId(Long userId, List<OrderStatus> statuses);
+
+    @Query("SELECT o FROM Order o JOIN OrderSheet os ON o.orderSheet.id = os.id WHERE os.user.id = :userId AND o.deletedAt IS NULL")
+    List<Order> findByUserId(Long userId);
 
     // TODO: user 가 탈퇴한 경우 해당 메소드 어떻게 처리할 것인가?
     /**

--- a/src/main/java/com/programmers/smrtstore/domain/orderManagement/order/presentation/dto/res/OrderPreviewResponse.java
+++ b/src/main/java/com/programmers/smrtstore/domain/orderManagement/order/presentation/dto/res/OrderPreviewResponse.java
@@ -1,0 +1,34 @@
+package com.programmers.smrtstore.domain.orderManagement.order.presentation.dto.res;
+
+import com.programmers.smrtstore.domain.orderManagement.order.domain.entity.Order;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class OrderPreviewResponse {
+    private String orderId;
+    private String orderDate;
+    private String orderStatus;
+    private Integer orderTotalPrice;
+
+    @Builder
+    public OrderPreviewResponse(
+        String orderId, String orderDate, String orderStatus, Integer orderTotalPrice
+    ) {
+        this.orderId = orderId;
+        this.orderDate = orderDate;
+        this.orderStatus = orderStatus;
+        this.orderTotalPrice = orderTotalPrice;
+    }
+
+    public static OrderPreviewResponse from(
+        Order order
+    ) {
+        return OrderPreviewResponse.builder()
+            .orderId(order.getId())
+            .orderDate(order.getOrderDate().toString())
+            .orderStatus(order.getOrderStatus().toString())
+            .orderTotalPrice(order.getTotalPrice())
+            .build();
+    }
+}


### PR DESCRIPTION
## 🚀 개발 사항
User 의 주문 내역
- `getOrderPreviewsByUserId()`

User의 활성화된 주문 count 서비스 구현
- `getActiveOrderCountByUserId()`

### 이슈 번호
- close #228 
- close #232

## 특이 사항 🫶 
활성화 된 주문 상태

```
  PAYMENT_WAITING,
  PAYMENT_COMPLETED,
  DELIVERY_PREPARING,
  DELIVERING_BEFORE,
  DELIVERING,
  DELIVERED,
  DISPATCH_DELAYED
```
