### PR TITLE
[FEAT] Controller Test에서 활용할 Security Annotation 구현

### DIFF
--- a/src/test/java/com/programmers/smrtstore/core/support/WithMockCustomUser.java
+++ b/src/test/java/com/programmers/smrtstore/core/support/WithMockCustomUser.java
@@ -1,0 +1,13 @@
+package com.programmers.smrtstore.core.support;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockCustomerUserSecurityContextFactory.class)
+public @interface WithMockCustomUser {
+    long userId() default 1L;
+
+    String role() default "ROLE_ADMIN";
+}

--- a/src/test/java/com/programmers/smrtstore/core/support/WithMockCustomerUserSecurityContextFactory.java
+++ b/src/test/java/com/programmers/smrtstore/core/support/WithMockCustomerUserSecurityContextFactory.java
@@ -1,0 +1,36 @@
+package com.programmers.smrtstore.core.support;
+
+import com.programmers.smrtstore.domain.auth.jwt.JwtAuthenticationContext;
+import com.programmers.smrtstore.domain.auth.jwt.JwtHelper;
+import com.programmers.smrtstore.domain.auth.jwt.JwtToken;
+import java.util.Date;
+import java.util.List;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class WithMockCustomerUserSecurityContextFactory implements
+    WithSecurityContextFactory<WithMockCustomUser> {
+
+    private final JwtHelper jwtHelper;
+
+    public WithMockCustomerUserSecurityContextFactory() {
+        this.jwtHelper = new JwtHelper("test",
+            "test",
+            1, 3,
+            Date::new);
+    }
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockCustomUser customUser) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority(customUser.role()));
+        JwtToken token = jwtHelper.sign(customUser.userId(),
+            authorities.stream().map(GrantedAuthority::getAuthority).toArray(String[]::new));
+        var auth = new JwtAuthenticationContext(token, null, authorities);
+        context.setAuthentication(auth);
+        return context;
+    }
+}


### PR DESCRIPTION
## 🚀 개발 사항
`@WithMockCustomUser` 구현
- 테스트시 인증이 필요한 Endpoint의 경우 위의 어노테이션을 작성해주세요!
- 추가로 내부요청의 경우라 csrf() 활성화가 필요합니다!

<img width="375" alt="image" src="https://github.com/smRt-Egg/BE-05-smRt-store/assets/85854384/af549048-fa86-4bf2-82e7-badcb713b688">


### 이슈 번호
- close #231 

## 특이 사항 🫶 
